### PR TITLE
Bandwidth Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,13 @@ CMakeFiles
 *.cmake
 build
 
+**/*.o
+**/*.so*
+**/*.a
+src/rtl_adsb
+src/rtl_eeprom
+src/rtl_fm
+src/rtl_power
+src/rtl_test
+
 debianize/*.deb

--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -26,6 +26,7 @@ extern "C" {
 
 #include <stdint.h>
 #include <rtl-sdr_export.h>
+#include <rtl_tcp.h>
 
 typedef struct rtlsdr_dev rtlsdr_dev_t;
 

--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -221,9 +221,14 @@ RTLSDR_API int rtlsdr_set_tuner_gain(rtlsdr_dev_t *dev, int gain);
  *
  * \param dev the device handle given by rtlsdr_open()
  * \param bw bandwidth in Hz. Zero means automatic BW selection.
+ * \param applied_bw is applied bandwidth in Hz, or 0 if unknown
+ * \param apply_bw: 1 to really apply configure the tuner chip; 0 for just returning applied_bw
  * \return 0 on success
  */
-RTLSDR_API int rtlsdr_set_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw);
+RTLSDR_API int rtlsdr_set_and_get_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw, uint32_t *applied_bw, int apply_bw );
+
+RTLSDR_API int rtlsdr_set_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw );
+
 
 /*!
  * Get actual gain the device is configured to.

--- a/include/rtl_tcp.h
+++ b/include/rtl_tcp.h
@@ -1,0 +1,51 @@
+/*
+ * rtl-sdr, turns your Realtek RTL2832 based DVB dongle into a SDR receiver
+ * Copyright (C) 2012-2013 by Steve Markgraf <steve@steve-m.de>
+ * Copyright (C) 2012 by Dimitri Stolnikov <horiz0n@gmx.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __RTL_TCP_H
+#define __RTL_TCP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * This enum defines the possible commands in rtl_tcp
+ */
+enum RTL_TCP_COMMANDS {
+    SET_FREQUENCY             = 0x01,
+    SET_SAMPLE_RATE           = 0x02,
+    SET_GAIN_MODE             = 0x03,
+    SET_GAIN                  = 0x04,
+    SET_FREQUENCY_CORRECTION  = 0x05,
+    SET_IF_STAGE              = 0x06,
+    SET_TEST_MODE             = 0x07,
+    SET_AGC_MODE              = 0x08,
+    SET_DIRECT_SAMPLING       = 0x09,
+    SET_OFFSET_TUNING         = 0x0A,
+    SET_RTL_CRYSTAL           = 0x0B,
+    SET_TUNER_CRYSTAL         = 0x0C,
+    SET_TUNER_GAIN_BY_INDEX   = 0x0D,
+    SET_TUNER_BANDWIDTH       = 0x0E
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/tuner_r82xx.h
+++ b/include/tuner_r82xx.h
@@ -115,6 +115,6 @@ int r82xx_set_freq(struct r82xx_priv *priv, uint32_t freq);
 //int r82xx_set_gain(struct r82xx_priv *priv, int set_manual_gain, int gain);
 int r82xx_set_gain(struct r82xx_priv *priv, int set_manual_gain, int gain, int extended_mode, int lna_gain, int mixer_gain, int vga_gain);
 
-int r82xx_set_bandwidth(struct r82xx_priv *priv, int bandwidth,  uint32_t rate);
+int r82xx_set_bandwidth(struct r82xx_priv *priv, int bandwidth,  uint32_t rate, uint32_t * applied_bw, int apply);
 
 #endif

--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -160,6 +160,20 @@ int verbose_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate)
 	return r;
 }
 
+int verbose_set_bandwidth(rtlsdr_dev_t *dev, uint32_t bandwidth)
+{
+  int r;
+  r = rtlsdr_set_tuner_bandwidth(dev, bandwidth);
+  if (r < 0) {
+    fprintf(stderr, "WARNING: Failed to set bandwidth.\n");
+  } else if (bandwidth > 0) {
+    fprintf(stderr, "Bandwidth set to %u Hz.\n", bandwidth);
+  } else {
+    fprintf(stderr, "Bandwidth set to automatic.\n");
+  }
+  return r;
+}
+
 int verbose_direct_sampling(rtlsdr_dev_t *dev, int on)
 {
 	int r;

--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -163,13 +163,15 @@ int verbose_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate)
 int verbose_set_bandwidth(rtlsdr_dev_t *dev, uint32_t bandwidth)
 {
   int r;
-  r = rtlsdr_set_tuner_bandwidth(dev, bandwidth);
+  uint32_t applied_bw = 0;
+  /* r = rtlsdr_set_tuner_bandwidth(dev, bandwidth); */
+  r = rtlsdr_set_and_get_tuner_bandwidth(dev, bandwidth, &applied_bw, 1 /* =apply_bw */);
   if (r < 0) {
     fprintf(stderr, "WARNING: Failed to set bandwidth.\n");
   } else if (bandwidth > 0) {
-    fprintf(stderr, "Bandwidth set to %u Hz.\n", bandwidth);
+    fprintf(stderr, "Bandwidth set to %u Hz resulted in %u Hz.\n", bandwidth, applied_bw);
   } else {
-    fprintf(stderr, "Bandwidth set to automatic.\n");
+    fprintf(stderr, "Bandwidth set to automatic resulted in %u Hz.\n", applied_bw);
   }
   return r;
 }

--- a/src/convenience/convenience.h
+++ b/src/convenience/convenience.h
@@ -78,6 +78,17 @@ int verbose_set_frequency(rtlsdr_dev_t *dev, uint32_t frequency);
 int verbose_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate);
 
 /*!
+ * Set device bandwidth and report status on stderr
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \param frequency in Hz
+ * \return 0 on success
+ */
+
+int verbose_set_bandwidth(rtlsdr_dev_t *dev, uint32_t bandwidth);
+
+
+/*!
  * Enable or disable the direct sampling mode and report status on stderr
  *
  * \param dev the device handle given by rtlsdr_open()

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -10,11 +10,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <errno.h>
@@ -60,7 +60,7 @@ typedef struct rtlsdr_tuner_iface {
 	int (*init)(void *);
 	int (*exit)(void *);
 	int (*set_freq)(void *, uint32_t freq /* Hz */);
-    int (*set_bw)(void *, int bw /* Hz */, uint32_t *applied_bw /* configured bw in Hz */, int apply /* 1 == configure it!, 0 == deliver applied_bw */);
+	int (*set_bw)(void *, int bw /* Hz */, uint32_t *applied_bw /* configured bw in Hz */, int apply /* 1 == configure it!, 0 == deliver applied_bw */);
 	int (*set_gain)(void *, int gain /* tenth dB */);
 	int (*set_if_gain)(void *, int stage, int gain /* tenth dB */);
 	int (*set_gain_mode)(void *, int manual);
@@ -149,8 +149,8 @@ int e4000_set_freq(void *dev, uint32_t freq) {
 int e4000_set_bw(void *dev, int bw, uint32_t *applied_bw, int apply) {
 	int r = 0;
 	rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
-    if(!apply)
-        return 0;
+	if(!apply)
+		return 0;
 
 	r |= e4k_if_filter_bw_set(&devt->e4k_s, E4K_IF_FILTER_MIX, bw);
 	r |= e4k_if_filter_bw_set(&devt->e4k_s, E4K_IF_FILTER_RC, bw);
@@ -210,9 +210,9 @@ int _fc2580_set_freq(void *dev, uint32_t freq) {
 	return fc2580_SetRfFreqHz(dev, freq);
 }
 int fc2580_set_bw(void *dev, int bw, uint32_t *applied_bw, int apply) {
-    if(!apply)
-        return 0;
-    return fc2580_SetBandwidthMode(dev, 1);
+	if(!apply)
+		return 0;
+	return fc2580_SetBandwidthMode(dev, 1);
 }
 int fc2580_set_gain(void *dev, int gain) { return 0; }
 int fc2580_set_gain_mode(void *dev, int manual) { return 0; }
@@ -251,11 +251,12 @@ int r820t_set_bw(void *dev, int bw, uint32_t *applied_bw, int apply) {
 	int r;
 	rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
 
-    r = r82xx_set_bandwidth(&devt->r82xx_p, bw, devt->rate, applied_bw, apply);
-    if(!apply)
-        return 0;
-    if(r < 0)
-		return r;
+	r = r82xx_set_bandwidth(&devt->r82xx_p, bw, devt->rate, applied_bw, apply);
+	if(!apply)
+			return 0;
+	if(r < 0)
+			return r;
+
 	r = rtlsdr_set_if_freq(devt, r);
 	if (r)
 		return r;
@@ -263,18 +264,18 @@ int r820t_set_bw(void *dev, int bw, uint32_t *applied_bw, int apply) {
 }
 
 int r820t_set_gain(void *dev, int gain) {
-  rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
-  return r82xx_set_gain(&devt->r82xx_p, 1, gain, 0, 0, 0, 0);
+	rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
+	return r82xx_set_gain(&devt->r82xx_p, 1, gain, 0, 0, 0, 0);
 }
 
 int r820t_set_gain_ext(void *dev, int lna_gain, int mixer_gain, int vga_gain) {
-  rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
-  return r82xx_set_gain(&devt->r82xx_p, 0, 0, 1, lna_gain, mixer_gain, vga_gain);
+	rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
+	return r82xx_set_gain(&devt->r82xx_p, 0, 0, 1, lna_gain, mixer_gain, vga_gain);
 }
 
 int r820t_set_gain_mode(void *dev, int manual) {
 	rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
-  return r82xx_set_gain(&devt->r82xx_p, manual, 0, 0, 0, 0, 0);
+	return r82xx_set_gain(&devt->r82xx_p, manual, 0, 0, 0, 0, 0);
 }
 
 /* definition order must match enum rtlsdr_tuner */
@@ -647,7 +648,7 @@ void rtlsdr_init_baseband(rtlsdr_dev_t *dev)
 	rtlsdr_demod_write_reg(dev, 1, 0x15, 0x00, 1);
 	rtlsdr_demod_write_reg(dev, 1, 0x16, 0x0000, 2);
 
-	/* clear both DDC shift and IF frequency registers  */
+	/* clear both DDC shift and IF frequency registers	*/
 	for (i = 0; i < 6; i++)
 		rtlsdr_demod_write_reg(dev, 1, 0x16 + i, 0x00, 1);
 
@@ -766,7 +767,7 @@ int rtlsdr_set_xtal_freq(rtlsdr_dev_t *dev, uint32_t rtl_freq, uint32_t tuner_fr
 
 		/* read corrected clock value into e4k and r82xx structure */
 		if (rtlsdr_get_xtal_freq(dev, NULL, &dev->e4k_s.vco.fosc) ||
-		    rtlsdr_get_xtal_freq(dev, NULL, &dev->r82xx_c.xtal))
+			rtlsdr_get_xtal_freq(dev, NULL, &dev->r82xx_c.xtal))
 			return -3;
 
 		/* update xtal-dependent settings */
@@ -794,7 +795,7 @@ int rtlsdr_get_xtal_freq(rtlsdr_dev_t *dev, uint32_t *rtl_freq, uint32_t *tuner_
 }
 
 int rtlsdr_get_usb_strings(rtlsdr_dev_t *dev, char *manufact, char *product,
-			    char *serial)
+							char *serial)
 {
 	struct libusb_device_descriptor dd;
 	libusb_device *device = NULL;
@@ -813,22 +814,22 @@ int rtlsdr_get_usb_strings(rtlsdr_dev_t *dev, char *manufact, char *product,
 	if (manufact) {
 		memset(manufact, 0, buf_max);
 		libusb_get_string_descriptor_ascii(dev->devh, dd.iManufacturer,
-						   (unsigned char *)manufact,
-						   buf_max);
+							 (unsigned char *)manufact,
+							 buf_max);
 	}
 
 	if (product) {
 		memset(product, 0, buf_max);
 		libusb_get_string_descriptor_ascii(dev->devh, dd.iProduct,
-						   (unsigned char *)product,
-						   buf_max);
+							 (unsigned char *)product,
+							 buf_max);
 	}
 
 	if (serial) {
 		memset(serial, 0, buf_max);
 		libusb_get_string_descriptor_ascii(dev->devh, dd.iSerialNumber,
-						   (unsigned char *)serial,
-						   buf_max);
+							 (unsigned char *)serial,
+							 buf_max);
 	}
 
 	return 0;
@@ -944,7 +945,7 @@ int rtlsdr_set_freq_correction(rtlsdr_dev_t *dev, int ppm)
 
 	/* read corrected clock value into e4k and r82xx structure */
 	if (rtlsdr_get_xtal_freq(dev, NULL, &dev->e4k_s.vco.fosc) ||
-	    rtlsdr_get_xtal_freq(dev, NULL, &dev->r82xx_c.xtal))
+			rtlsdr_get_xtal_freq(dev, NULL, &dev->r82xx_c.xtal))
 		return -3;
 
 	if (dev->freq) /* retune to apply new correction value */
@@ -973,16 +974,16 @@ int rtlsdr_get_tuner_gains(rtlsdr_dev_t *dev, int *gains)
 {
 	/* all gain values are expressed in tenths of a dB */
 	const int e4k_gains[] = { -10, 15, 40, 65, 90, 115, 140, 165, 190, 215,
-				  240, 290, 340, 420 };
+					240, 290, 340, 420 };
 	const int fc0012_gains[] = { -99, -40, 71, 179, 192 };
 	const int fc0013_gains[] = { -99, -73, -65, -63, -60, -58, -54, 58, 61,
-				       63, 65, 67, 68, 70, 71, 179, 181, 182,
-				       184, 186, 188, 191, 197 };
+							 	  63, 65, 67, 68, 70, 71, 179, 181, 182,
+							 	  184, 186, 188, 191, 197 };
 	const int fc2580_gains[] = { 0 /* no gain values */ };
 	const int r82xx_gains[] = { 0, 9, 14, 27, 37, 77, 87, 125, 144, 157,
-				     166, 197, 207, 229, 254, 280, 297, 328,
-				     338, 364, 372, 386, 402, 421, 434, 439,
-				     445, 480, 496 };
+								166, 197, 207, 229, 254, 280, 297, 328,
+						 		338, 364, 372, 386, 402, 421, 434, 439,
+						 		445, 480, 496 };
 	const int unknown_gains[] = { 0 /* no gain values */ };
 
 	const int *ptr = NULL;
@@ -1027,22 +1028,22 @@ int rtlsdr_set_and_get_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw, uint32_t 
 {
 	int r = 0;
 
-    *applied_bw = 0;    /* unknown */
+		*applied_bw = 0;		/* unknown */
 
 	if (!dev || !dev->tuner)
 		return -1;
 
-    if(!apply_bw)
-    {
-        if (dev->tuner->set_bw) {
-            r = dev->tuner->set_bw(dev, bw > 0 ? bw : dev->rate, applied_bw, apply_bw);
-        }
-        return r;
-    }
+	if(!apply_bw)
+	{
+		if (dev->tuner->set_bw) {
+			r = dev->tuner->set_bw(dev, bw > 0 ? bw : dev->rate, applied_bw, apply_bw);
+		}
+		return r;
+	}
 
 	if (dev->tuner->set_bw) {
 		rtlsdr_set_i2c_repeater(dev, 1);
-        r = dev->tuner->set_bw(dev, bw > 0 ? bw : dev->rate, applied_bw, apply_bw);
+		r = dev->tuner->set_bw(dev, bw > 0 ? bw : dev->rate, applied_bw, apply_bw);
 		rtlsdr_set_i2c_repeater(dev, 0);
 		if (r)
 			return r;
@@ -1053,8 +1054,8 @@ int rtlsdr_set_and_get_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw, uint32_t 
 
 int rtlsdr_set_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw )
 {
-    uint32_t applied_bw = 0;
-    return rtlsdr_set_and_get_tuner_bandwidth(dev, bw, &applied_bw, 1 /* =apply_bw */ );
+	uint32_t applied_bw = 0;
+	return rtlsdr_set_and_get_tuner_bandwidth(dev, bw, &applied_bw, 1 /* =apply_bw */ );
 }
 
 
@@ -1153,7 +1154,7 @@ int rtlsdr_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate)
 
 	/* check if the rate is supported by the resampler */
 	if ((samp_rate <= 225000) || (samp_rate > 3200000) ||
-	   ((samp_rate > 300000) && (samp_rate <= 900000))) {
+		 ((samp_rate > 300000) && (samp_rate <= 900000))) {
 		fprintf(stderr, "Invalid sample rate: %u Hz\n", samp_rate);
 		return -EINVAL;
 	}
@@ -1170,9 +1171,9 @@ int rtlsdr_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate)
 	dev->rate = (uint32_t)real_rate;
 
 	if (dev->tuner && dev->tuner->set_bw) {
-        uint32_t applied_bw = 0;
+		uint32_t applied_bw = 0;
 		rtlsdr_set_i2c_repeater(dev, 1);
-        dev->tuner->set_bw(dev, dev->bw > 0 ? dev->bw : dev->rate, &applied_bw, 1);
+		dev->tuner->set_bw(dev, dev->bw > 0 ? dev->bw : dev->rate, &applied_bw, 1);
 		rtlsdr_set_i2c_repeater(dev, 0);
 	}
 
@@ -1254,7 +1255,7 @@ int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on)
 		}
 
 		if ((dev->tuner_type == RTLSDR_TUNER_R820T) ||
-		    (dev->tuner_type == RTLSDR_TUNER_R828D)) {
+				(dev->tuner_type == RTLSDR_TUNER_R828D)) {
 			r |= rtlsdr_set_if_freq(dev, R82XX_IF_FREQ);
 
 			/* enable spectrum inversion */
@@ -1298,7 +1299,7 @@ int rtlsdr_set_offset_tuning(rtlsdr_dev_t *dev, int on)
 		return -1;
 
 	if ((dev->tuner_type == RTLSDR_TUNER_R820T) ||
-	    (dev->tuner_type == RTLSDR_TUNER_R828D))
+			(dev->tuner_type == RTLSDR_TUNER_R828D))
 		return -2;
 
 	if (dev->direct_sampling)
@@ -1309,7 +1310,7 @@ int rtlsdr_set_offset_tuning(rtlsdr_dev_t *dev, int on)
 	r |= rtlsdr_set_if_freq(dev, dev->offs_freq);
 
 	if (dev->tuner && dev->tuner->set_bw) {
-        uint32_t applied_bw = 0;
+				uint32_t applied_bw = 0;
 		rtlsdr_set_i2c_repeater(dev, 1);
 		if (on) {
 			bw = 2 * dev->offs_freq;
@@ -1318,7 +1319,7 @@ int rtlsdr_set_offset_tuning(rtlsdr_dev_t *dev, int on)
 		} else {
 			bw = dev->rate;
 		}
-        dev->tuner->set_bw(dev, bw, &applied_bw, 1);
+				dev->tuner->set_bw(dev, bw, &applied_bw, 1);
 		rtlsdr_set_i2c_repeater(dev, 0);
 	}
 
@@ -1420,7 +1421,7 @@ const char *rtlsdr_get_device_name(uint32_t index)
 }
 
 int rtlsdr_get_device_usb_strings(uint32_t index, char *manufact,
-				   char *product, char *serial)
+					 char *product, char *serial)
 {
 	int r = -2;
 	int i;
@@ -1450,9 +1451,9 @@ int rtlsdr_get_device_usb_strings(uint32_t index, char *manufact,
 				r = libusb_open(list[i], &devt.devh);
 				if (!r) {
 					r = rtlsdr_get_usb_strings(&devt,
-								   manufact,
-								   product,
-								   serial);
+									 manufact,
+									 product,
+									 serial);
 					libusb_close(devt.devh);
 				}
 				break;
@@ -1762,7 +1763,7 @@ static void LIBUSB_CALL _libusb_callback(struct libusb_transfer *xfer)
 			dev->xfer_errors++;
 
 		if (dev->xfer_errors >= dev->xfer_buf_num ||
-		    LIBUSB_TRANSFER_NO_DEVICE == xfer->status) {
+				LIBUSB_TRANSFER_NO_DEVICE == xfer->status) {
 #endif
 			dev->dev_lost = 1;
 			rtlsdr_cancel_async(dev);
@@ -1788,7 +1789,7 @@ static int _rtlsdr_alloc_async_buffers(rtlsdr_dev_t *dev)
 
 	if (!dev->xfer) {
 		dev->xfer = malloc(dev->xfer_buf_num *
-				   sizeof(struct libusb_transfer *));
+					 sizeof(struct libusb_transfer *));
 
 		for(i = 0; i < dev->xfer_buf_num; ++i)
 			dev->xfer[i] = libusb_alloc_transfer(0);
@@ -1796,7 +1797,7 @@ static int _rtlsdr_alloc_async_buffers(rtlsdr_dev_t *dev)
 
 	if (!dev->xfer_buf) {
 		dev->xfer_buf = malloc(dev->xfer_buf_num *
-					   sizeof(unsigned char *));
+						 sizeof(unsigned char *));
 
 		for(i = 0; i < dev->xfer_buf_num; ++i)
 			dev->xfer_buf[i] = malloc(dev->xfer_buf_len);
@@ -1837,7 +1838,7 @@ static int _rtlsdr_free_async_buffers(rtlsdr_dev_t *dev)
 }
 
 int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
-			  uint32_t buf_num, uint32_t buf_len)
+				uint32_t buf_num, uint32_t buf_len)
 {
 	unsigned int i;
 	int r = 0;
@@ -1871,13 +1872,13 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 
 	for(i = 0; i < dev->xfer_buf_num; ++i) {
 		libusb_fill_bulk_transfer(dev->xfer[i],
-					  dev->devh,
-					  0x81,
-					  dev->xfer_buf[i],
-					  dev->xfer_buf_len,
-					  _libusb_callback,
-					  (void *)dev,
-					  BULK_TIMEOUT);
+						dev->devh,
+						0x81,
+						dev->xfer_buf[i],
+						dev->xfer_buf_len,
+						_libusb_callback,
+						(void *)dev,
+						BULK_TIMEOUT);
 
 		r = libusb_submit_transfer(dev->xfer[i]);
 		if (r < 0) {
@@ -1889,7 +1890,7 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 
 	while (RTLSDR_INACTIVE != dev->async_status) {
 		r = libusb_handle_events_timeout_completed(dev->ctx, &tv,
-							   &dev->async_cancel);
+								 &dev->async_cancel);
 		if (r < 0) {
 			/*fprintf(stderr, "handle_events returned: %d\n", r);*/
 			if (r == LIBUSB_ERROR_INTERRUPTED) /* stray signal */
@@ -1914,7 +1915,7 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 					 * to allow transfer status to
 					 * propagate */
 					libusb_handle_events_timeout_completed(dev->ctx,
-									       &zerotv, NULL);
+												 &zerotv, NULL);
 					if (r < 0)
 						continue;
 
@@ -1927,7 +1928,7 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 				 * be handled before exiting after we
 				 * just cancelled all transfers */
 				libusb_handle_events_timeout_completed(dev->ctx,
-								       &zerotv, NULL);
+											 &zerotv, NULL);
 				break;
 			}
 		}

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -108,6 +108,7 @@ struct dongle_state
 	int      dev_index;
 	uint32_t freq;
 	uint32_t rate;
+  uint32_t bandwidth;
 	int      gain;
 	int16_t  buf16[MAXIMUM_BUF_LENGTH];
 	uint32_t buf_len;
@@ -203,7 +204,8 @@ void usage(void)
 		"\t    raw mode outputs 2x16 bit IQ pairs\n"
 		"\t[-s sample_rate (default: 24k)]\n"
 		"\t[-d device_index (default: 0)]\n"
-		"\t[-g tuner_gain (default: automatic)]\n"
+    "\t[-g tuner_gain (default: automatic)]\n"
+    "\t[-w tuner_bandwidth (default: automatic)]\n"
 		"\t[-l squelch_level (default: 0/off)]\n"
 		"\t[-L N  prints levels every N calculations]\n"
 		"\t    output are comma separated values (csv):\n"
@@ -1160,7 +1162,7 @@ int main(int argc, char **argv)
 	output_init(&output);
 	controller_init(&controller);
 
-	while ((opt = getopt(argc, argv, "d:f:g:s:b:l:L:o:t:r:p:E:q:F:A:M:c:v:h")) != -1) {
+	while ((opt = getopt(argc, argv, "d:f:g:s:b:l:L:o:t:r:p:E:q:F:A:M:c:v:h:w:")) != -1) {
 		switch (opt) {
 		case 'd':
 			dongle.dev_index = verbose_device_search(optarg);
@@ -1274,6 +1276,9 @@ int main(int argc, char **argv)
 		case 'v':
 			verbosity = (int)atof(optarg);
 			break;
+    case 'w':
+      dongle.bandwidth = (uint32_t)atofs(optarg);
+      break;
 		case 'h':
 		default:
 			usage();
@@ -1341,6 +1346,8 @@ int main(int argc, char **argv)
 	}
 
 	verbose_ppm_set(dongle.dev, dongle.ppm_error);
+
+  verbose_set_bandwidth(dongle.dev, dongle.bandwidth);
 
 	if (strcmp(output.filename, "-") == 0) { /* Write samples to stdout */
 		output.file = stdout;

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -1056,6 +1056,7 @@ void dongle_init(struct dongle_state *s)
 	s->direct_sampling = 0;
 	s->offset_tuning = 0;
 	s->demod_target = &demod;
+  s->bandwidth = 0;
 }
 
 void demod_init(struct demod_state *s)

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -1348,7 +1348,21 @@ int main(int argc, char **argv)
 
 	verbose_ppm_set(dongle.dev, dongle.ppm_error);
 
-  verbose_set_bandwidth(dongle.dev, dongle.bandwidth);
+    verbose_set_bandwidth(dongle.dev, dongle.bandwidth);
+
+    if (verbosity && dongle.bandwidth)
+    {
+      int r;
+      uint32_t in_bw, out_bw, last_bw = 0;
+      for ( in_bw = 1; in_bw < 3200; ++in_bw )
+      {
+        r = rtlsdr_set_and_get_tuner_bandwidth(dongle.dev, in_bw*1000, &out_bw, 0 /* =apply_bw */);
+        if ( r == 0 && ( out_bw != last_bw || in_bw == 1 ) )
+          fprintf(stderr, "device sets bandwidth %u Hz for bw para >= %u kHz\n", out_bw, in_bw );
+        last_bw = out_bw;
+      }
+      fprintf(stderr,"\n");
+    }
 
 	if (strcmp(output.filename, "-") == 0) { /* Write samples to stdout */
 		output.file = stdout;

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -30,23 +30,23 @@
  * (no many-to-many locks)
  *
  * todo:
- *       sanity checks
- *       scale squelch to other input parameters
- *       test all the demodulations
- *       pad output on hop
- *       frequency ranges could be stored better
- *       scaled AM demod amplification
- *       auto-hop after time limit
- *       peak detector to tune onto stronger signals
- *       fifo for active hop frequency
- *       clips
- *       noise squelch
- *       merge stereo patch
- *       merge soft agc patch
- *       merge udp patch
- *       testmode to detect overruns
- *       watchdog to reset bad dongle
- *       fix oversampling
+ *	   sanity checks
+ *	   scale squelch to other input parameters
+ *	   test all the demodulations
+ *	   pad output on hop
+ *	   frequency ranges could be stored better
+ *	   scaled AM demod amplification
+ *	   auto-hop after time limit
+ *	   peak detector to tune onto stronger signals
+ *	   fifo for active hop frequency
+ *	   clips
+ *	   noise squelch
+ *	   merge stereo patch
+ *	   merge soft agc patch
+ *	   merge udp patch
+ *	   testmode to detect overruns
+ *	   watchdog to reset bad dongle
+ *	   fix oversampling
  */
 
 #include <errno.h>
@@ -102,54 +102,54 @@ static double levelSum = 0.0;
 
 struct dongle_state
 {
-	int      exit_flag;
+	int	  exit_flag;
 	pthread_t thread;
 	rtlsdr_dev_t *dev;
-	int      dev_index;
+	int	  dev_index;
 	uint32_t freq;
 	uint32_t rate;
   uint32_t bandwidth;
-	int      gain;
+	int	  gain;
 	int16_t  buf16[MAXIMUM_BUF_LENGTH];
 	uint32_t buf_len;
-	int      ppm_error;
-	int      offset_tuning;
-	int      direct_sampling;
-	int      mute;
+	int	  ppm_error;
+	int	  offset_tuning;
+	int	  direct_sampling;
+	int	  mute;
 	struct demod_state *demod_target;
 };
 
 struct demod_state
 {
-	int      exit_flag;
+	int	  exit_flag;
 	pthread_t thread;
 	int16_t  lowpassed[MAXIMUM_BUF_LENGTH];
-	int      lp_len;
+	int	  lp_len;
 	int16_t  lp_i_hist[10][6];
 	int16_t  lp_q_hist[10][6];
 	int16_t  result[MAXIMUM_BUF_LENGTH];
 	int16_t  droop_i_hist[9];
 	int16_t  droop_q_hist[9];
-	int      result_len;
-	int      rate_in;
-	int      rate_out;
-	int      rate_out2;
-	int      now_r, now_j;
-	int      pre_r, pre_j;
-	int      prev_index;
-	int      downsample;    /* min 1, max 256 */
-	int      post_downsample;
-	int      output_scale;
-	int      squelch_level, conseq_squelch, squelch_hits, terminate_on_squelch;
-	int      downsample_passes;
-	int      comp_fir_size;
-	int      custom_atan;
-	int      deemph, deemph_a;
-	int      now_lpr;
-	int      prev_lpr_index;
-	int      dc_block_audio, dc_avg, adc_block_const;
-	int      dc_block_raw, dc_avgI, dc_avgQ, rdc_block_const;
-	void     (*mode_demod)(struct demod_state*);
+	int	  result_len;
+	int	  rate_in;
+	int	  rate_out;
+	int	  rate_out2;
+	int	  now_r, now_j;
+	int	  pre_r, pre_j;
+	int	  prev_index;
+	int	  downsample;	/* min 1, max 256 */
+	int	  post_downsample;
+	int	  output_scale;
+	int	  squelch_level, conseq_squelch, squelch_hits, terminate_on_squelch;
+	int	  downsample_passes;
+	int	  comp_fir_size;
+	int	  custom_atan;
+	int	  deemph, deemph_a;
+	int	  now_lpr;
+	int	  prev_lpr_index;
+	int	  dc_block_audio, dc_avg, adc_block_const;
+	int	  dc_block_raw, dc_avgI, dc_avgQ, rdc_block_const;
+	void	 (*mode_demod)(struct demod_state*);
 	pthread_rwlock_t rw;
 	pthread_cond_t ready;
 	pthread_mutex_t ready_m;
@@ -158,13 +158,13 @@ struct demod_state
 
 struct output_state
 {
-	int      exit_flag;
+	int	  exit_flag;
 	pthread_t thread;
-	FILE     *file;
-	char     *filename;
+	FILE	 *file;
+	char	 *filename;
 	int16_t  result[MAXIMUM_BUF_LENGTH];
-	int      result_len;
-	int      rate;
+	int	  result_len;
+	int	  rate;
 	pthread_rwlock_t rw;
 	pthread_cond_t ready;
 	pthread_mutex_t ready_m;
@@ -172,13 +172,13 @@ struct output_state
 
 struct controller_state
 {
-	int      exit_flag;
+	int	  exit_flag;
 	pthread_t thread;
 	uint32_t freqs[FREQUENCIES_LIMIT];
-	int      freq_len;
-	int      freq_now;
-	int      edge;
-	int      wb_mode;
+	int	  freq_len;
+	int	  freq_now;
+	int	  edge;
+	int	  wb_mode;
 	pthread_cond_t hop;
 	pthread_mutex_t hop_m;
 };
@@ -195,44 +195,44 @@ void usage(void)
 		"rtl_fm, a simple narrow band FM demodulator for RTL2832 based DVB-T receivers\n\n"
 		"Use:\trtl_fm -f freq [-options] [filename]\n"
 		"\t-f frequency_to_tune_to [Hz]\n"
-		"\t    use multiple -f for scanning (requires squelch)\n"
-		"\t    ranges supported, -f 118M:137M:25k\n"
+		"\t	use multiple -f for scanning (requires squelch)\n"
+		"\t	ranges supported, -f 118M:137M:25k\n"
 		"\t[-v verbosity (default: 0)]\n"
 		"\t[-M modulation (default: fm)]\n"
-		"\t    fm or nbfm or nfm, wbfm or wfm, raw or iq, am, usb, lsb\n"
-		"\t    wbfm == -M fm -s 170k -o 4 -A fast -r 32k -l 0 -E deemp\n"
-		"\t    raw mode outputs 2x16 bit IQ pairs\n"
+		"\t	fm or nbfm or nfm, wbfm or wfm, raw or iq, am, usb, lsb\n"
+		"\t	wbfm == -M fm -s 170k -o 4 -A fast -r 32k -l 0 -E deemp\n"
+		"\t	raw mode outputs 2x16 bit IQ pairs\n"
 		"\t[-s sample_rate (default: 24k)]\n"
 		"\t[-d device_index (default: 0)]\n"
-    "\t[-g tuner_gain (default: automatic)]\n"
-    "\t[-w tuner_bandwidth (default: automatic)]\n"
+	"\t[-g tuner_gain (default: automatic)]\n"
+	"\t[-w tuner_bandwidth (default: automatic)]\n"
 		"\t[-l squelch_level (default: 0/off)]\n"
 		"\t[-L N  prints levels every N calculations]\n"
-		"\t    output are comma separated values (csv):\n"
-		"\t    mean since last output, max since last output, overall max, squelch\n"
+		"\t	output are comma separated values (csv):\n"
+		"\t	mean since last output, max since last output, overall max, squelch\n"
 		"\t[-c de-emphasis_time_constant in us for wbfm. 'us' or 'eu' for 75/50 us (default: us)]\n"
-		//"\t    for fm squelch is inverted\n"
+		//"\t	for fm squelch is inverted\n"
 		"\t[-o oversampling (default: 1, 4 recommended)]\n"
 		"\t[-p ppm_error (default: 0)]\n"
 		"\t[-E enable_option (default: none)]\n"
-		"\t    use multiple -E to enable multiple options\n"
-		"\t    edge:   enable lower edge tuning\n"
-		"\t    rdc:     enable dc blocking filter on raw I/Q data at capture rate\n"
-		"\t    adc:     enable dc blocking filter on demodulated audio\n"
-		"\t    dc:      same as adc\n"
-		"\t    deemp:  enable de-emphasis filter\n"
-		"\t    direct: enable direct sampling\n"
-		"\t    offset: enable offset tuning\n"
+		"\t	use multiple -E to enable multiple options\n"
+		"\t	edge:   enable lower edge tuning\n"
+		"\t	rdc:	 enable dc blocking filter on raw I/Q data at capture rate\n"
+		"\t	adc:	 enable dc blocking filter on demodulated audio\n"
+		"\t	dc:	  same as adc\n"
+		"\t	deemp:  enable de-emphasis filter\n"
+		"\t	direct: enable direct sampling\n"
+		"\t	offset: enable offset tuning\n"
 		"\t[-q dc_avg_factor for option rdc (default: 9)]\n"
 		"\tfilename ('-' means stdout)\n"
-		"\t    omitting the filename also uses stdout\n\n"
+		"\t	omitting the filename also uses stdout\n\n"
 		"Experimental options:\n"
 		"\t[-r resample_rate (default: none / same as -s)]\n"
 		"\t[-t squelch_delay (default: 10)]\n"
-		"\t    +values will mute/scan, -values will exit\n"
+		"\t	+values will mute/scan, -values will exit\n"
 		"\t[-F fir_size (default: off)]\n"
-		"\t    enables low-leakage downsample filter\n"
-		"\t    size can be 0 or 9.  0 has bad roll off\n"
+		"\t	enables low-leakage downsample filter\n"
+		"\t	size can be 0 or 9.  0 has bad roll off\n"
 		"\t[-A std/fast/lut choose atan math (default: std)]\n"
 		//"\t[-C clip_path (default: off)\n"
 		//"\t (create time stamped raw clips, requires squelch)\n"
@@ -242,7 +242,7 @@ void usage(void)
 		"\n"
 		"Produces signed 16 bit ints, use Sox or aplay to hear them.\n"
 		"\trtl_fm ... | play -t raw -r 24k -es -b 16 -c 1 -V1 -\n"
-		"\t           | aplay -r 24k -f S16_LE -t raw -c 1\n"
+		"\t		   | aplay -r 24k -f S16_LE -t raw -c 1\n"
 		"\t  -M wbfm  | play -r 32k ... \n"
 		"\t  -s 22050 | multimon -t raw /dev/stdin\n\n");
 	exit(1);
@@ -441,7 +441,7 @@ void generic_fir(int16_t *data, int length, int *fir, int16_t *hist)
 		sum += (hist[1] + hist[7]) * fir[2];
 		sum += (hist[2] + hist[6]) * fir[3];
 		sum += (hist[3] + hist[5]) * fir[4];
-		sum +=            hist[4]  * fir[5];
+		sum +=			hist[4]  * fir[5];
 		data[d] = sum >> 15 ;
 		hist[0] = hist[1];
 		hist[1] = hist[2];
@@ -1056,7 +1056,7 @@ void dongle_init(struct dongle_state *s)
 	s->direct_sampling = 0;
 	s->offset_tuning = 0;
 	s->demod_target = &demod;
-  s->bandwidth = 0;
+	s->bandwidth = 0;
 }
 
 void demod_init(struct demod_state *s)
@@ -1070,10 +1070,10 @@ void demod_init(struct demod_state *s)
 	s->downsample_passes = 0;
 	s->comp_fir_size = 0;
 	s->prev_index = 0;
-	s->post_downsample = 1;  // once this works, default = 4
+	s->post_downsample = 1;	// once this works, default = 4
 	s->custom_atan = 0;
 	s->deemph = 0;
-	s->rate_out2 = -1;  // flag for disabled
+	s->rate_out2 = -1;	// flag for disabled
 	s->mode_demod = &fm_demod;
 	s->pre_j = s->pre_r = s->now_r = s->now_j = 0;
 	s->prev_lpr_index = 0;
@@ -1277,9 +1277,9 @@ int main(int argc, char **argv)
 		case 'v':
 			verbosity = (int)atof(optarg);
 			break;
-    case 'w':
-      dongle.bandwidth = (uint32_t)atofs(optarg);
-      break;
+	case 'w':
+		dongle.bandwidth = (uint32_t)atofs(optarg);
+		break;
 		case 'h':
 		default:
 			usage();
@@ -1348,21 +1348,23 @@ int main(int argc, char **argv)
 
 	verbose_ppm_set(dongle.dev, dongle.ppm_error);
 
-    verbose_set_bandwidth(dongle.dev, dongle.bandwidth);
+ 	verbose_set_bandwidth(dongle.dev, dongle.bandwidth);
 
-    if (verbosity && dongle.bandwidth)
-    {
-      int r;
-      uint32_t in_bw, out_bw, last_bw = 0;
-      for ( in_bw = 1; in_bw < 3200; ++in_bw )
-      {
-        r = rtlsdr_set_and_get_tuner_bandwidth(dongle.dev, in_bw*1000, &out_bw, 0 /* =apply_bw */);
-        if ( r == 0 && ( out_bw != last_bw || in_bw == 1 ) )
-          fprintf(stderr, "device sets bandwidth %u Hz for bw para >= %u kHz\n", out_bw, in_bw );
-        last_bw = out_bw;
-      }
-      fprintf(stderr,"\n");
-    }
+	verbose_set_bandwidth(dongle.dev, dongle.bandwidth);
+
+	if (verbosity && dongle.bandwidth)
+	{
+	  int r;
+	  uint32_t in_bw, out_bw, last_bw = 0;
+	  for ( in_bw = 1; in_bw < 3200; ++in_bw )
+	  {
+		r = rtlsdr_set_and_get_tuner_bandwidth(dongle.dev, in_bw*1000, &out_bw, 0 /* =apply_bw */);
+		if ( r == 0 && ( out_bw != last_bw || in_bw == 1 ) )
+		  fprintf(stderr, "device sets bandwidth %u Hz for bw para >= %u kHz\n", out_bw, in_bw );
+		last_bw = out_bw;
+	  }
+	  fprintf(stderr,"\n");
+	}
 
 	if (strcmp(output.filename, "-") == 0) { /* Write samples to stdout */
 		output.file = stdout;

--- a/src/rtl_tcp.c
+++ b/src/rtl_tcp.c
@@ -357,7 +357,7 @@ static void *command_worker(void *arg)
 			set_gain_by_index(dev, ntohl(cmd.param));
 			break;
     case SET_TUNER_BANDWIDTH:
-      printf("set tuner bandwidth to %i\n", ntohl(cmd.param));
+      printf("set tuner bandwidth to %i Hz\n", ntohl(cmd.param));
       rtlsdr_set_tuner_bandwidth(dev, ntohl(cmd.param));
       break;
 		default:

--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -250,7 +250,7 @@ static void shadow_store(struct r82xx_priv *priv, uint8_t reg, const uint8_t *va
 }
 
 static int r82xx_write(struct r82xx_priv *priv, uint8_t reg, const uint8_t *val,
-		       unsigned int len)
+			   unsigned int len)
 {
 	int rc, size, pos = 0;
 
@@ -561,8 +561,8 @@ static int r82xx_set_pll(struct r82xx_priv *priv, uint32_t freq)
 }
 
 static int r82xx_sysfreq_sel(struct r82xx_priv *priv, uint32_t freq,
-			     enum r82xx_tuner_type type,
-			     uint32_t delsys)
+				 enum r82xx_tuner_type type,
+				 uint32_t delsys)
 {
 	int rc;
 	uint8_t mixer_top, lna_top, cp_cur, div_buf_cur, lna_vth_l, mixer_vth_l;
@@ -1083,97 +1083,97 @@ int r82xx_set_gain(struct r82xx_priv *priv, int set_manual_gain, int gain,
   uint8_t data[4];
 
   if (extended_mode) {
-    /*
-    // LNA auto off
-    rc = r82xx_write_reg_mask(priv, 0x05, 0x10, 0x10);
-    if (rc < 0)
-      return rc;
+	/*
+	// LNA auto off
+	rc = r82xx_write_reg_mask(priv, 0x05, 0x10, 0x10);
+	if (rc < 0)
+	  return rc;
 
-    // Mixer auto off
-    rc = r82xx_write_reg_mask(priv, 0x07, 0, 0x10);
-    if (rc < 0)
-      return rc;
+	// Mixer auto off
+	rc = r82xx_write_reg_mask(priv, 0x07, 0, 0x10);
+	if (rc < 0)
+	  return rc;
 
-    rc = r82xx_read(priv, 0x00, data, sizeof(data));
-    if (rc < 0)
-      return rc;
-    */
+	rc = r82xx_read(priv, 0x00, data, sizeof(data));
+	if (rc < 0)
+	  return rc;
+	*/
 
-    /* Set LNA */
-    rc = r82xx_write_reg_mask(priv, 0x05, lna_gain, 0x0f);
-    if (rc < 0)
-      return rc;
+	/* Set LNA */
+	rc = r82xx_write_reg_mask(priv, 0x05, lna_gain, 0x0f);
+	if (rc < 0)
+	  return rc;
 
-    /* Set Mixer */
-    rc = r82xx_write_reg_mask(priv, 0x07, mixer_gain, 0x0f);
-    if (rc < 0)
-      return rc;
+	/* Set Mixer */
+	rc = r82xx_write_reg_mask(priv, 0x07, mixer_gain, 0x0f);
+	if (rc < 0)
+	  return rc;
 
-    /* Set VGA */
-    rc = r82xx_write_reg_mask(priv, 0x0c, vga_gain, 0x9f);
-    if (rc < 0)
-      return rc;
+	/* Set VGA */
+	rc = r82xx_write_reg_mask(priv, 0x0c, vga_gain, 0x9f);
+	if (rc < 0)
+	  return rc;
 
-    return 0;
+	return 0;
   }
 
   if (set_manual_gain) {
 
-    /* LNA auto off */
-    rc = r82xx_write_reg_mask(priv, 0x05, 0x10, 0x10);
-    if (rc < 0)
-      return rc;
+	/* LNA auto off */
+	rc = r82xx_write_reg_mask(priv, 0x05, 0x10, 0x10);
+	if (rc < 0)
+	  return rc;
 
-     /* Mixer auto off */
-    rc = r82xx_write_reg_mask(priv, 0x07, 0, 0x10);
-    if (rc < 0)
-      return rc;
+	 /* Mixer auto off */
+	rc = r82xx_write_reg_mask(priv, 0x07, 0, 0x10);
+	if (rc < 0)
+	  return rc;
 
-    rc = r82xx_read(priv, 0x00, data, sizeof(data));
-    if (rc < 0)
-      return rc;
+	rc = r82xx_read(priv, 0x00, data, sizeof(data));
+	if (rc < 0)
+	  return rc;
 
-    /* set fixed VGA gain for now (16.3 dB) */
-    rc = r82xx_write_reg_mask(priv, 0x0c, 0x08, 0x9f);
-    if (rc < 0)
-      return rc;
+	/* set fixed VGA gain for now (16.3 dB) */
+	rc = r82xx_write_reg_mask(priv, 0x0c, 0x08, 0x9f);
+	if (rc < 0)
+	  return rc;
 
-    for (i = 0; i < 15; i++) {
-      if (total_gain >= gain)
-        break;
+	for (i = 0; i < 15; i++) {
+	  if (total_gain >= gain)
+		break;
 
-      total_gain += r82xx_lna_gain_steps[++lna_index];
+	  total_gain += r82xx_lna_gain_steps[++lna_index];
 
-      if (total_gain >= gain)
-        break;
+	  if (total_gain >= gain)
+		break;
 
-      total_gain += r82xx_mixer_gain_steps[++mix_index];
-    }
+	  total_gain += r82xx_mixer_gain_steps[++mix_index];
+	}
 
-    /* set LNA gain */
-    rc = r82xx_write_reg_mask(priv, 0x05, lna_index, 0x0f);
-    if (rc < 0)
-      return rc;
+	/* set LNA gain */
+	rc = r82xx_write_reg_mask(priv, 0x05, lna_index, 0x0f);
+	if (rc < 0)
+	  return rc;
 
-    /* set Mixer gain */
-    rc = r82xx_write_reg_mask(priv, 0x07, mix_index, 0x0f);
-    if (rc < 0)
-      return rc;
+	/* set Mixer gain */
+	rc = r82xx_write_reg_mask(priv, 0x07, mix_index, 0x0f);
+	if (rc < 0)
+	  return rc;
   } else {
-    /* LNA */
-    rc = r82xx_write_reg_mask(priv, 0x05, 0, 0x10);
-    if (rc < 0)
-      return rc;
+	/* LNA */
+	rc = r82xx_write_reg_mask(priv, 0x05, 0, 0x10);
+	if (rc < 0)
+	  return rc;
 
-    /* Mixer */
-    rc = r82xx_write_reg_mask(priv, 0x07, 0x10, 0x10);
-    if (rc < 0)
-      return rc;
+	/* Mixer */
+	rc = r82xx_write_reg_mask(priv, 0x07, 0x10, 0x10);
+	if (rc < 0)
+	  return rc;
 
-    /* set fixed VGA gain for now (26.5 dB) */
-    rc = r82xx_write_reg_mask(priv, 0x0c, 0x0b, 0x9f);
-    if (rc < 0)
-      return rc;
+	/* set fixed VGA gain for now (26.5 dB) */
+	rc = r82xx_write_reg_mask(priv, 0x0c, 0x0b, 0x9f);
+	if (rc < 0)
+	  return rc;
   }
 
   return 0;
@@ -1197,35 +1197,35 @@ int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate, uint32_t
 
 	if (bw > 7000000) {
 		// BW: 8 MHz
-        *applied_bw = 8000000;
+		*applied_bw = 8000000;
 		reg_0a = 0x10;
 		reg_0b = 0x0b;
-        if (apply)
-            priv->int_freq = 4570000;
+		if (apply)
+			priv->int_freq = 4570000;
 	} else if (bw > 6000000) {
 		// BW: 7 MHz
-        *applied_bw = 7000000;
-        reg_0a = 0x10;
+		*applied_bw = 7000000;
+		reg_0a = 0x10;
 		reg_0b = 0x2a;
-        if (apply)
-            priv->int_freq = 4570000;
+		if (apply)
+			priv->int_freq = 4570000;
 	} else if (bw > r82xx_if_low_pass_bw_table[0] + FILT_HP_BW1 + FILT_HP_BW2) {
 		// BW: 6 MHz
-        *applied_bw = 6000000;
-        reg_0a = 0x10;
+		*applied_bw = 6000000;
+		reg_0a = 0x10;
 		reg_0b = 0x6b;
-        if (apply)
-            priv->int_freq = 3570000;
+		if (apply)
+			priv->int_freq = 3570000;
 	} else {
 		reg_0a = 0x00;
 		reg_0b = 0x80;
-        if (apply)
-            priv->int_freq = 2300000;
+		if (apply)
+			priv->int_freq = 2300000;
 
 		if (bw > r82xx_if_low_pass_bw_table[0] + FILT_HP_BW1) {
 			bw -= FILT_HP_BW2;
-            if (apply)
-                priv->int_freq += FILT_HP_BW2;
+			if (apply)
+				priv->int_freq += FILT_HP_BW2;
 			real_bw += FILT_HP_BW2;
 		} else {
 			reg_0b |= 0x20;
@@ -1233,8 +1233,8 @@ int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate, uint32_t
 
 		if (bw > r82xx_if_low_pass_bw_table[0]) {
 			bw -= FILT_HP_BW1;
-            if (apply)
-                priv->int_freq += FILT_HP_BW1;
+			if (apply)
+				priv->int_freq += FILT_HP_BW1;
 			real_bw += FILT_HP_BW1;
 		} else {
 			reg_0b |= 0x40;
@@ -1249,14 +1249,14 @@ int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate, uint32_t
 		reg_0b |= 15 - i;
 		real_bw += r82xx_if_low_pass_bw_table[i];
 
-        *applied_bw = real_bw;
+		*applied_bw = real_bw;
 
-        if (apply)
-            priv->int_freq -= real_bw / 2;
+		if (apply)
+			priv->int_freq -= real_bw / 2;
 	}
 
-    if (!apply)
-        return 0;
+	if (!apply)
+		return 0;
 
 	rc = r82xx_write_reg_mask(priv, 0x0a, reg_0a, 0x10);
 	if (rc < 0)
@@ -1292,7 +1292,7 @@ int r82xx_set_freq(struct r82xx_priv *priv, uint32_t freq)
 	air_cable1_in = (freq > MHZ(345)) ? 0x00 : 0x60;
 
 	if ((priv->cfg->rafael_chip == CHIP_R828D) &&
-	    (air_cable1_in != priv->input)) {
+		(air_cable1_in != priv->input)) {
 		priv->input = air_cable1_in;
 		rc = r82xx_write_reg_mask(priv, 0x05, air_cable1_in, 0x60);
 	}

--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -1187,7 +1187,7 @@ static const int r82xx_if_low_pass_bw_table[] = {
 
 #define FILT_HP_BW1 350000
 #define FILT_HP_BW2 380000
-int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate)
+int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate, uint32_t * applied_bw, int apply)
 {
 	int rc;
 	unsigned int i;
@@ -1197,27 +1197,35 @@ int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate)
 
 	if (bw > 7000000) {
 		// BW: 8 MHz
+        *applied_bw = 8000000;
 		reg_0a = 0x10;
 		reg_0b = 0x0b;
-		priv->int_freq = 4570000;
+        if (apply)
+            priv->int_freq = 4570000;
 	} else if (bw > 6000000) {
 		// BW: 7 MHz
-		reg_0a = 0x10;
+        *applied_bw = 7000000;
+        reg_0a = 0x10;
 		reg_0b = 0x2a;
-		priv->int_freq = 4570000;
+        if (apply)
+            priv->int_freq = 4570000;
 	} else if (bw > r82xx_if_low_pass_bw_table[0] + FILT_HP_BW1 + FILT_HP_BW2) {
 		// BW: 6 MHz
-		reg_0a = 0x10;
+        *applied_bw = 6000000;
+        reg_0a = 0x10;
 		reg_0b = 0x6b;
-		priv->int_freq = 3570000;
+        if (apply)
+            priv->int_freq = 3570000;
 	} else {
 		reg_0a = 0x00;
 		reg_0b = 0x80;
-		priv->int_freq = 2300000;
+        if (apply)
+            priv->int_freq = 2300000;
 
 		if (bw > r82xx_if_low_pass_bw_table[0] + FILT_HP_BW1) {
 			bw -= FILT_HP_BW2;
-			priv->int_freq += FILT_HP_BW2;
+            if (apply)
+                priv->int_freq += FILT_HP_BW2;
 			real_bw += FILT_HP_BW2;
 		} else {
 			reg_0b |= 0x20;
@@ -1225,7 +1233,8 @@ int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate)
 
 		if (bw > r82xx_if_low_pass_bw_table[0]) {
 			bw -= FILT_HP_BW1;
-			priv->int_freq += FILT_HP_BW1;
+            if (apply)
+                priv->int_freq += FILT_HP_BW1;
 			real_bw += FILT_HP_BW1;
 		} else {
 			reg_0b |= 0x40;
@@ -1240,8 +1249,14 @@ int r82xx_set_bandwidth(struct r82xx_priv *priv, int bw, uint32_t rate)
 		reg_0b |= 15 - i;
 		real_bw += r82xx_if_low_pass_bw_table[i];
 
-		priv->int_freq -= real_bw / 2;
+        *applied_bw = real_bw;
+
+        if (apply)
+            priv->int_freq -= real_bw / 2;
 	}
+
+    if (!apply)
+        return 0;
 
 	rc = r82xx_write_reg_mask(priv, 0x0a, reg_0a, 0x10);
 	if (rc < 0)


### PR DESCRIPTION
Updates on **rtl_tcp**
-   Added Bandwidth Parameter (`-w`) to **rtl_tcp** to set the device bandwidth through cmd args
-   Added Bandwidth Network Parameter (`0x0E`) to **rtl_tcp** to set the device bandwidth through network
-   Added `RTL_TCP_COMMANDS` enum to better organize the network commands
-   Added binary files to gitignore

Device Bandwidth to Convenience and **rtl_fm**
-   Added Device Bandwidth to Convenience
-   Added Device Bandwidth to **rtl_fm** (`-w` option)
