### PR TITLE
Fix clang warning about shifting a negative signed value

### DIFF
--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -502,7 +502,7 @@ int polar_disc_lut(int ar, int aj, int br, int bj)
 
 	if (x_abs >= atan_lut_size) {
 		/* we can use linear range, but it is not necessary */
-		return (cj > 0) ? 1<<13 : -1<<13;
+		return (cj > 0) ? 1<<13 : -(1<<13);
 	}
 
 	if (x > 0) {


### PR DESCRIPTION
There is a new warning when compiling librtlsdr with clang 7.3.0, this PR fixes:

```
[ 66%] Building C object src/CMakeFiles/rtl_fm.dir/rtl_fm.c.o
/Users/admin/rf/librtlsdr/src/rtl_fm.c:505:31: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
                return (cj > 0) ? 1<<13 : -1<<13;
                                          ~~^
1 warning generated.
```
