### PR TITLE
Disable RPC for Windows Builds

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -24,6 +24,11 @@
 extern "C" {
 #endif
 
+#ifndef WIN32
+#define _ENABLE_RPC
+#endif
+
+
 #include <stdint.h>
 #include <rtl-sdr_export.h>
 #include <rtl_tcp.h>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ MACRO(RTLSDR_APPEND_SRCS)
     LIST(APPEND rtlsdr_srcs ${ARGV})
 ENDMACRO(RTLSDR_APPEND_SRCS)
 
+if(!WIN32)
 RTLSDR_APPEND_SRCS(
     librtlsdr.c
     tuner_e4k.c
@@ -31,6 +32,16 @@ RTLSDR_APPEND_SRCS(
     rtlsdr_rpc.c
     rtlsdr_rpc_msg.c
 )
+else()
+RTLSDR_APPEND_SRCS(
+    librtlsdr.c
+    tuner_e4k.c
+    tuner_fc0012.c
+    tuner_fc0013.c
+    tuner_fc2580.c
+    tuner_r82xx.c
+)
+endif()
 
 ########################################################################
 # Set up Windows DLL resource files
@@ -94,8 +105,12 @@ add_executable(rtl_ir rtl_ir.c)
 add_executable(rtl_eeprom rtl_eeprom.c)
 add_executable(rtl_adsb rtl_adsb.c)
 add_executable(rtl_power rtl_power.c)
-add_executable(rtl_rpcd rtl_rpcd.c rtlsdr_rpc_msg.c)
-set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_sdr rtl_tcp rtl_test rtl_fm rtl_ir rtl_eeprom rtl_adsb rtl_power rtl_rpcd)
+if (!WIN32)
+    add_executable(rtl_rpcd rtl_rpcd.c rtlsdr_rpc_msg.c)
+    set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_sdr rtl_tcp rtl_test rtl_fm rtl_ir rtl_eeprom rtl_adsb rtl_power rtl_rpcd)
+else()
+    set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_sdr rtl_tcp rtl_test rtl_fm rtl_ir rtl_eeprom rtl_adsb rtl_power)
+endif()
 
 target_link_libraries(rtl_sdr rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}
@@ -129,10 +144,13 @@ target_link_libraries(rtl_power rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
+if(!WIN32)
 target_link_libraries(rtl_rpcd rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
+endif()
+
 if(UNIX)
 target_link_libraries(rtl_fm m)
 target_link_libraries(rtl_ir m)
@@ -154,7 +172,7 @@ target_link_libraries(rtl_ir libgetopt_static)
 target_link_libraries(rtl_eeprom libgetopt_static)
 target_link_libraries(rtl_adsb libgetopt_static)
 target_link_libraries(rtl_power libgetopt_static)
-target_link_libraries(rtl_rpcd ws2_32 libgetopt_static)
+#target_link_libraries(rtl_rpcd ws2_32 libgetopt_static)
 set_property(TARGET rtl_sdr APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_tcp APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_test APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
@@ -163,7 +181,7 @@ set_property(TARGET rtl_ir APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_eeprom APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_adsb APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_power APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
-set_property(TARGET rtl_rpcd APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
+#set_property(TARGET rtl_rpcd APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 endif()
 ########################################################################
 # Install built library files & utilities

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ MACRO(RTLSDR_APPEND_SRCS)
     LIST(APPEND rtlsdr_srcs ${ARGV})
 ENDMACRO(RTLSDR_APPEND_SRCS)
 
-if(!WIN32)
+if(NOT WIN32)
 RTLSDR_APPEND_SRCS(
     librtlsdr.c
     tuner_e4k.c
@@ -105,7 +105,7 @@ add_executable(rtl_ir rtl_ir.c)
 add_executable(rtl_eeprom rtl_eeprom.c)
 add_executable(rtl_adsb rtl_adsb.c)
 add_executable(rtl_power rtl_power.c)
-if (!WIN32)
+if (NOT WIN32)
     add_executable(rtl_rpcd rtl_rpcd.c rtlsdr_rpc_msg.c)
     set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_sdr rtl_tcp rtl_test rtl_fm rtl_ir rtl_eeprom rtl_adsb rtl_power rtl_rpcd)
 else()
@@ -144,7 +144,7 @@ target_link_libraries(rtl_power rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
-if(!WIN32)
+if(NOT WIN32)
 target_link_libraries(rtl_rpcd rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -28,8 +28,9 @@
 #endif
 
 #include <libusb.h>
+#ifndef WIN32
 #include "rtlsdr_rpc.h"
-
+#endif
 /*
  * All libusb callback functions should be marked with the LIBUSB_CALL macro
  * to ensure that they are compiled with the same calling convention as libusb.
@@ -795,10 +796,12 @@ int rtlsdr_set_xtal_freq(rtlsdr_dev_t *dev, uint32_t rtl_freq, uint32_t tuner_fr
 {
 	int r = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_xtal_freq(dev, rtl_freq, tuner_freq);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -836,10 +839,12 @@ int rtlsdr_set_xtal_freq(rtlsdr_dev_t *dev, uint32_t rtl_freq, uint32_t tuner_fr
 
 int rtlsdr_get_xtal_freq(rtlsdr_dev_t *dev, uint32_t *rtl_freq, uint32_t *tuner_freq)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_xtal_freq(dev, rtl_freq, tuner_freq);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -863,10 +868,12 @@ int rtlsdr_get_usb_strings(rtlsdr_dev_t *dev, char *manufact, char *product,
 	const int buf_max = 256;
 	int r = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_usb_strings(dev, manufact, product, serial);
 	}
+	#endif
 
 	if (!dev || !dev->devh)
 		return -1;
@@ -907,10 +914,12 @@ int rtlsdr_write_eeprom(rtlsdr_dev_t *dev, uint8_t *data, uint8_t offset, uint16
 	int i;
 	uint8_t cmd[2];
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_write_eeprom(dev, data, offset, len);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -948,11 +957,12 @@ int rtlsdr_read_eeprom(rtlsdr_dev_t *dev, uint8_t *data, uint8_t offset, uint16_
 {
 	int r = 0;
 	int i;
-
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_read_eeprom(dev, data, offset, len);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -977,12 +987,12 @@ int rtlsdr_read_eeprom(rtlsdr_dev_t *dev, uint8_t *data, uint8_t offset, uint16_
 int rtlsdr_set_center_freq(rtlsdr_dev_t *dev, uint32_t freq)
 {
 	int r = -1;
-
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_center_freq(dev, freq);
 	}
-
+	#endif
 	if (!dev || !dev->tuner)
 		return -1;
 
@@ -1004,10 +1014,12 @@ int rtlsdr_set_center_freq(rtlsdr_dev_t *dev, uint32_t freq)
 
 uint32_t rtlsdr_get_center_freq(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_center_freq(dev);
 	}
+	#endif
 
 	if (!dev)
 		return 0;
@@ -1018,11 +1030,12 @@ uint32_t rtlsdr_get_center_freq(rtlsdr_dev_t *dev)
 int rtlsdr_set_freq_correction(rtlsdr_dev_t *dev, int ppm)
 {
 	int r = 0;
-
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_freq_correction(dev, ppm);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1047,10 +1060,12 @@ int rtlsdr_set_freq_correction(rtlsdr_dev_t *dev, int ppm)
 
 int rtlsdr_get_freq_correction(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_freq_correction(dev);
 	}
+	#endif
 
 	if (!dev)
 		return 0;
@@ -1060,10 +1075,12 @@ int rtlsdr_get_freq_correction(rtlsdr_dev_t *dev)
 
 enum rtlsdr_tuner rtlsdr_get_tuner_type(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return (enum rtlsdr_tuner)rtlsdr_rpc_get_tuner_type(dev);
 	}
+	#endif
 
 	if (!dev)
 		return RTLSDR_TUNER_UNKNOWN;
@@ -1090,10 +1107,12 @@ int rtlsdr_get_tuner_gains(rtlsdr_dev_t *dev, int *gains)
 	const int *ptr = NULL;
 	int len = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_tuner_gains(dev, gains);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1170,10 +1189,12 @@ int rtlsdr_set_tuner_gain(rtlsdr_dev_t *dev, int gain)
 {
 	int r = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_tuner_gain(dev, gain);
 	}
+	#endif
 
 	if (!dev || !dev->tuner)
 		return -1;
@@ -1215,10 +1236,12 @@ int rtlsdr_set_tuner_gain_ext(rtlsdr_dev_t *dev, int lna_gain, int mixer_gain, i
 
 int rtlsdr_get_tuner_gain(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_tuner_gain(dev);
 	}
+	#endif
 
 	if (!dev)
 		return 0;
@@ -1230,10 +1253,12 @@ int rtlsdr_set_tuner_if_gain(rtlsdr_dev_t *dev, int stage, int gain)
 {
 	int r = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_tuner_if_gain(dev, stage, gain);
 	}
+	#endif
 
 	if (!dev || !dev->tuner)
 		return -1;
@@ -1251,10 +1276,12 @@ int rtlsdr_set_tuner_gain_mode(rtlsdr_dev_t *dev, int mode)
 {
 	int r = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_tuner_gain_mode(dev, mode);
 	}
+	#endif
 
 	if (!dev || !dev->tuner)
 		return -1;
@@ -1275,10 +1302,12 @@ int rtlsdr_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate)
 	uint32_t rsamp_ratio, real_rsamp_ratio;
 	double real_rate;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_sample_rate(dev, samp_rate);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1328,10 +1357,12 @@ int rtlsdr_set_sample_rate(rtlsdr_dev_t *dev, uint32_t samp_rate)
 
 uint32_t rtlsdr_get_sample_rate(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_sample_rate(dev);
 	}
+	#endif
 
 	if (!dev)
 		return 0;
@@ -1341,10 +1372,12 @@ uint32_t rtlsdr_get_sample_rate(rtlsdr_dev_t *dev)
 
 int rtlsdr_set_testmode(rtlsdr_dev_t *dev, int on)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_testmode(dev, on);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1354,10 +1387,12 @@ int rtlsdr_set_testmode(rtlsdr_dev_t *dev, int on)
 
 int rtlsdr_set_agc_mode(rtlsdr_dev_t *dev, int on)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_agc_mode(dev, on);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1369,10 +1404,12 @@ int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on)
 {
 	int r = 0;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_direct_sampling(dev, on);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1435,10 +1472,12 @@ int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on)
 
 int rtlsdr_get_direct_sampling(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_direct_sampling(dev);
 	}
+	#endif
  
 	if (!dev)
 		return -1;
@@ -1451,10 +1490,12 @@ int rtlsdr_set_offset_tuning(rtlsdr_dev_t *dev, int on)
 	int r = 0;
 	int bw;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_set_offset_tuning(dev, on);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1492,10 +1533,12 @@ int rtlsdr_set_offset_tuning(rtlsdr_dev_t *dev, int on)
 
 int rtlsdr_get_offset_tuning(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_offset_tuning(dev);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1527,10 +1570,12 @@ uint32_t rtlsdr_get_device_count(void)
 	struct libusb_device_descriptor dd;
 	ssize_t cnt;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_device_count();
 	}
+	#endif
 
 	r = libusb_init(&ctx);
 	if(r < 0)
@@ -1562,10 +1607,12 @@ const char *rtlsdr_get_device_name(uint32_t index)
 	uint32_t device_count = 0;
 	ssize_t cnt;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_device_name(index);
 	}
+	#endif
 
 	r = libusb_init(&ctx);
 	if(r < 0)
@@ -1609,11 +1656,13 @@ int rtlsdr_get_device_usb_strings(uint32_t index, char *manufact,
 	uint32_t device_count = 0;
 	ssize_t cnt;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_device_usb_strings
 	    (index, manufact, product, serial);
 	}
+	#endif
 
 	r = libusb_init(&ctx);
 	if(r < 0)
@@ -1655,10 +1704,12 @@ int rtlsdr_get_index_by_serial(const char *serial)
 	int i, cnt, r;
 	char str[256];
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_get_index_by_serial(serial);
 	}
+	#endif
 
 	if (!serial)
 		return -1;
@@ -1689,10 +1740,12 @@ int rtlsdr_open(rtlsdr_dev_t **out_dev, uint32_t index)
 	uint8_t reg;
 	ssize_t cnt;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_open((void**)out_dev, index);
 	}
+	#endif
 
 	dev = malloc(sizeof(rtlsdr_dev_t));
 	if (NULL == dev)
@@ -1884,10 +1937,12 @@ err:
 
 int rtlsdr_close(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_close(dev);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1927,10 +1982,12 @@ int rtlsdr_close(rtlsdr_dev_t *dev)
 
 int rtlsdr_reset_buffer(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_reset_buffer(dev);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1943,10 +2000,12 @@ int rtlsdr_reset_buffer(rtlsdr_dev_t *dev)
 
 int rtlsdr_read_sync(rtlsdr_dev_t *dev, void *buf, int len, int *n_read)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_read_sync(dev, buf, len, n_read);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -1984,10 +2043,12 @@ static void LIBUSB_CALL _libusb_callback(struct libusb_transfer *xfer)
 
 int rtlsdr_wait_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_wait_async(dev, cb, ctx);
 	}
+	#endif
 
 	return rtlsdr_read_async(dev, cb, ctx, 0, 0);
 }
@@ -2058,10 +2119,12 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 	struct timeval zerotv = { 0, 0 };
 	enum rtlsdr_async_status next_status = RTLSDR_INACTIVE;
 
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_read_async(dev, cb, ctx, buf_num, buf_len);
 	}
+	#endif
 
 	if (!dev)
 		return -1;
@@ -2160,10 +2223,12 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 
 int rtlsdr_cancel_async(rtlsdr_dev_t *dev)
 {
+	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
 	  return rtlsdr_rpc_cancel_async(dev);
 	}
+	#endif
 
 	if (!dev)
 		return -1;


### PR DESCRIPTION
Disabling RPC in Windows builds. It uses POSIX calls and we should port it in the future.
