### PR TITLE
Added Bias T Support from RTL-SDR Blog V3 Dongle

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -419,6 +419,17 @@ RTLSDR_API int rtlsdr_cancel_async(rtlsdr_dev_t *dev);
  */
 RTLSDR_API int rtlsdr_ir_query(rtlsdr_dev_t *dev, uint8_t *buf, size_t buf_len);
 
+
+/*!
+ * Enable or disable the bias tee on GPIO PIN 0. (Works for rtl-sdr.com v3 dongles)
+ * See: http://www.rtl-sdr.com/rtl-sdr-blog-v-3-dongles-user-guide/
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \param on  1 for Bias T on. 0 for Bias T off.
+ * \return -1 if device is not initialized. 1 otherwise.
+ */
+RTLSDR_API int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rtl_tcp.h
+++ b/include/rtl_tcp.h
@@ -41,7 +41,8 @@ enum RTL_TCP_COMMANDS {
     SET_RTL_CRYSTAL           = 0x0B,
     SET_TUNER_CRYSTAL         = 0x0C,
     SET_TUNER_GAIN_BY_INDEX   = 0x0D,
-    SET_TUNER_BANDWIDTH       = 0x0E
+    SET_TUNER_BANDWIDTH       = 0x0E,
+    SET_BIAS_TEE              = 0x0F
 };
 
 #ifdef __cplusplus

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -636,7 +636,7 @@ void rtlsdr_set_gpio_output(rtlsdr_dev_t *dev, uint8_t gpio)
 	gpio = 1 << gpio;
 
 	r = rtlsdr_read_reg(dev, SYSB, GPD, 1);
-	rtlsdr_write_reg(dev, SYSB, GPO, r & ~gpio, 1);
+	rtlsdr_write_reg(dev, SYSB, GPD, r & ~gpio, 1); // CARL: Changed from rtlsdr_write_reg(dev, SYSB, GPO, r & ~gpio, 1); must be a bug in the old code
 	r = rtlsdr_read_reg(dev, SYSB, GPOE, 1);
 	rtlsdr_write_reg(dev, SYSB, GPOE, r | gpio, 1);
 }

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -2436,3 +2436,13 @@ err:
 	printf("failed=%d\n", ret);
 	return ret;
 }
+
+int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on) {
+	if (!dev)
+		return -1;
+
+	rtlsdr_set_gpio_output(dev, 0);
+	rtlsdr_set_gpio_bit(dev, 0, on);
+
+	return 1;
+}

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -220,6 +220,7 @@ void usage(void)
 		"\t[-p ppm_error (default: 0)]\n"
 		"\t[-E enable_option (default: none)]\n"
 		"\t	use multiple -E to enable multiple options\n"
+		"\t	biasT:  enable bias-T on GPIO PIN 0 (works for rtl-sdr.com v3 dongles)\n"
 		"\t	edge:   enable lower edge tuning\n"
 		"\t	rdc:    enable dc blocking filter on raw I/Q data at capture rate\n"
 		"\t	adc:    enable dc blocking filter on demodulated audio\n"
@@ -1164,6 +1165,7 @@ int main(int argc, char **argv)
 	int r, opt;
 	int dev_given = 0;
 	int custom_ppm = 0;
+	int enable_biastee = 0;
 	int timeConstant = 75; /* default: U.S. 75 uS */
 	int rtlagc = 0;
 	dongle_init(&dongle);
@@ -1225,6 +1227,8 @@ int main(int argc, char **argv)
 		case 'E':
 			if (strcmp("edge",  optarg) == 0) {
 				controller.edge = 1;}
+			if (strcmp("biasT", optarg) == 0 || strcmp("biast", optarg) == 0) {
+				enable_biastee = 1;}
 			if (strcmp("dc", optarg) == 0 || strcmp("adc", optarg) == 0) {
 				demod.dc_block_audio = 1;}
 			if (strcmp("rdc", optarg) == 0) {
@@ -1363,6 +1367,8 @@ int main(int argc, char **argv)
 	}
 
 	rtlsdr_set_agc_mode(dongle.dev, rtlagc);
+  
+	rtlsdr_set_bias_tee(dongle.dev, enable_biastee);
 
 	verbose_ppm_set(dongle.dev, dongle.ppm_error);
 

--- a/src/rtl_tcp.c
+++ b/src/rtl_tcp.c
@@ -376,6 +376,10 @@ static void *command_worker(void *arg)
 			printf("set tuner bandwidth to %i Hz\n", bandwidth);
 			verbose_set_bandwidth(dev, bandwidth);
 			break;
+		case SET_BIAS_TEE:
+			printf("setting bias-t to %d\n", ntohl(cmd.param));
+			rtlsdr_set_bias_tee(dev, ntohl(cmd.param));
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
I added Software Enabled Bias T support from V3 Dongle of RTLSDR Blog (see http://www.rtl-sdr.com/rtl-sdr-blog-v-3-dongles-user-guide/ )

I didn't got any V3 dongles yet (I ordered mine yesterday), I will test it when it arrives.
