### PR TITLE
Fix rtl-tcp.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ src/rtl_rpcd
 src/rtl_test
 
 debianize/*.deb
+.cproject
+.project

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -22,6 +22,7 @@
 ########################################################################
 install(FILES
     rtl-sdr.h
+    rtl_tcp.h
     rtl-sdr_export.h
     DESTINATION include
 )

--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -31,7 +31,6 @@ extern "C" {
 
 #include <stdint.h>
 #include <rtl-sdr_export.h>
-#include <rtl_tcp.h>
 
 typedef struct rtlsdr_dev rtlsdr_dev_t;
 

--- a/src/rtl_tcp.c
+++ b/src/rtl_tcp.c
@@ -43,6 +43,7 @@
 #include <pthread.h>
 
 #include "rtl-sdr.h"
+#include "rtl_tcp.h"
 #include "convenience/convenience.h"
 
 #ifdef _WIN32


### PR DESCRIPTION
-   So @f4exb was right to include the rtl_tcp.h in CMakeLists install. If anyone is making a C program that communicates with rtl_tcp, it will probably use the enums. (See PR #22 and issue #21)
-   Added rtl_tcp.h to CMakeLists install script and moved rtl_tcp.h include to rtl_tcp.c file
-   Added Eclipse gitignore (for anyone that uses eclipse to compile)
-   Closes Issue #21
