### PR TITLE
Fedora "libusb-1.0/libusb.h" support append.

### DIFF
--- a/fedora/libusb.h
+++ b/fedora/libusb.h
@@ -1,0 +1,6 @@
+#ifndef LIBUSB_H_FEDORA
+#define LIBUSB_H_FEDORA
+
+#include <libusb-1.0/libusb.h>
+
+#endif


### PR DESCRIPTION
The libusb header file in Fedora is "libusb-1.0/libusb.h". put the file to include paths for this change adaptation.