### PR TITLE
Fixes for compiling under MSVC 2013 and 2015

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 # Bug Fix
 #########################################################################
 OPTION(NEED_PTHREADS_WORKARROUND "PThreads Workarround for timespec")
-IF (DEFINED NEED_PTHREADS_WORKARROUND)
+IF (NEED_PTHREADS_WORKARROUND)
     ADD_DEFINITIONS(-DNEED_PTHREADS_WORKARROUND)
 ENDIF()
 

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -64,6 +64,9 @@
 #include <io.h>
 #include "getopt/getopt.h"
 #define usleep(x) Sleep(x/1000)
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#define snprintf _snprintf
+#endif
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 #define round(x) (x > 0.0 ? floor(x + 0.5): ceil(x - 0.5))
 #endif

--- a/src/rtl_ir.c
+++ b/src/rtl_ir.c
@@ -38,7 +38,7 @@
 #include <io.h>
 #include "getopt/getopt.h"
 #define usleep(x) Sleep(x/1000)
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #define round(x) (x > 0.0 ? floor(x + 0.5): ceil(x - 0.5))
 #endif
 #define _USE_MATH_DEFINES

--- a/src/rtl_tcp.c
+++ b/src/rtl_tcp.c
@@ -35,6 +35,7 @@
 #else
 #include <winsock2.h>
 #include "getopt/getopt.h"
+#define usleep(x) Sleep(x/1000)
 #endif
 
 #ifdef NEED_PTHREADS_WORKARROUND


### PR DESCRIPTION
Minor changes. Any additional ifdefs should match for forwards and backwards compatibility. More comments in the commits.

