### PR TITLE
Print frequency on PLL locking failure (r82xx)

### DIFF
--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -547,7 +547,7 @@ static int r82xx_set_pll(struct r82xx_priv *priv, uint32_t freq)
 	}
 
 	if (!(data[2] & 0x40)) {
-		fprintf(stderr, "[R82XX] PLL not locked!\n");
+		fprintf(stderr, "[R82XX] PLL not locked for %u Hz!\n", freq);
 		priv->has_lock = 0;
 		return 0;
 	}


### PR DESCRIPTION
Make the PLL lock failure error the same format as in tuner_e4k.c, it's nice to see the frequency in the output.