### PR TITLE
Add new call: rtlsdr_read_async_extbuf().

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -402,7 +402,10 @@ RTLSDR_API int rtlsdr_wait_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, v
 
 /*!
  * Read samples from the device asynchronously. This function will block until
- * it is being canceled using rtlsdr_cancel_async()
+ * it is being canceled using rtlsdr_cancel_async().
+ *
+ * This function allocate needed buffers internally with malloc() call.
+ * Buffers will be released by library.
  *
  * \param dev the device handle given by rtlsdr_open()
  * \param cb callback function to return received samples
@@ -419,6 +422,37 @@ RTLSDR_API int rtlsdr_read_async(rtlsdr_dev_t *dev,
 				 void *ctx,
 				 uint32_t buf_num,
 				 uint32_t buf_len);
+
+/*!
+ * Read samples from the device asynchronously. This function will block until
+ * it is being canceled using rtlsdr_cancel_async(). This function takes
+ * user-provided buffers and don't allocate or free any buffers internally.
+ *
+ * If buffers' parameters are invalid (wrong nuber of buffers or length of
+ * one buffer is not suitable) error is returned immideately. Number of buffers
+ * and length of one buffer are not optional.
+ *
+ * Library will never free buffers provided to this call.
+ *
+ * This call doesn't work via RPC.
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \param cb callback function to return received samples
+ * \param ctx user specific context to pass via the callback function
+ * \param buf_num buffer count, buf_num * buf_len = overall buffer size.
+ * \param buf_len buffer length, must be multiple of 512,
+ *		  should be a multiple of 16384 (URB size)
+ * \param bufs Array of size buf_num of pointers to buffer, each
+ *             buffer have size if buf_len
+ * 
+ * \return 0 on success
+ */
+RTLSDR_API int rtlsdr_read_async_extbuf(rtlsdr_dev_t *dev,
+				 rtlsdr_read_async_cb_t cb,
+				 void *ctx,
+				 uint32_t buf_num,
+				 uint32_t buf_len,
+				 unsigned char **bufs);
 
 /*!
  * Cancel all pending asynchronous operations on the device.

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -101,6 +101,7 @@ struct rtlsdr_dev {
 	uint32_t xfer_buf_len;
 	struct libusb_transfer **xfer;
 	unsigned char **xfer_buf;
+	int ext_buf;
 	rtlsdr_read_async_cb_t cb;
 	void *cb_ctx;
 	enum rtlsdr_async_status async_status;
@@ -2117,7 +2118,20 @@ int rtlsdr_wait_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx)
 	return rtlsdr_read_async(dev, cb, ctx, 0, 0);
 }
 
-static int _rtlsdr_alloc_async_buffers(rtlsdr_dev_t *dev)
+int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
+				uint32_t buf_num, uint32_t buf_len)
+{
+	#ifdef _ENABLE_RPC
+	if (rtlsdr_rpc_is_enabled())
+	{
+	  return rtlsdr_rpc_read_async(dev, cb, ctx, buf_num, buf_len);
+	}
+	#endif
+
+	return rtlsdr_read_async_extbuf(dev, cb, ctx, buf_num, buf_len, NULL);
+}
+
+static int _rtlsdr_alloc_async_buffers(rtlsdr_dev_t *dev, unsigned char **bufs)
 {
 	unsigned int i;
 
@@ -2136,8 +2150,15 @@ static int _rtlsdr_alloc_async_buffers(rtlsdr_dev_t *dev)
 		dev->xfer_buf = malloc(dev->xfer_buf_num *
 						 sizeof(unsigned char *));
 
-		for(i = 0; i < dev->xfer_buf_num; ++i)
-			dev->xfer_buf[i] = malloc(dev->xfer_buf_len);
+		if (!bufs) {
+			dev->ext_buf = 0;
+			for(i = 0; i < dev->xfer_buf_num; ++i)
+				dev->xfer_buf[i] = malloc(dev->xfer_buf_len);
+		} else  {
+			dev->ext_buf = 1;
+			for(i = 0; i < dev->xfer_buf_num; ++i)
+				dev->xfer_buf[i] = bufs[i];
+		}
 	}
 
 	return 0;
@@ -2162,11 +2183,12 @@ static int _rtlsdr_free_async_buffers(rtlsdr_dev_t *dev)
 	}
 
 	if (dev->xfer_buf) {
-		for(i = 0; i < dev->xfer_buf_num; ++i) {
-			if (dev->xfer_buf[i])
-				free(dev->xfer_buf[i]);
+		if (!dev->ext_buf) {
+			for(i = 0; i < dev->xfer_buf_num; ++i) {
+				if (dev->xfer_buf[i])
+					free(dev->xfer_buf[i]);
+			}
 		}
-
 		free(dev->xfer_buf);
 		dev->xfer_buf = NULL;
 	}
@@ -2174,8 +2196,9 @@ static int _rtlsdr_free_async_buffers(rtlsdr_dev_t *dev)
 	return 0;
 }
 
-int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
-				uint32_t buf_num, uint32_t buf_len)
+int rtlsdr_read_async_extbuf(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb,
+				void *ctx, uint32_t buf_num, uint32_t buf_len,
+				unsigned char **bufs)
 {
 	unsigned int i;
 	int r = 0;
@@ -2186,7 +2209,7 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 	#ifdef _ENABLE_RPC
 	if (rtlsdr_rpc_is_enabled())
 	{
-	  return rtlsdr_rpc_read_async(dev, cb, ctx, buf_num, buf_len);
+	  return -3;
 	}
 	#endif
 
@@ -2196,23 +2219,27 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 	if (RTLSDR_INACTIVE != dev->async_status)
 		return -2;
 
+	if (buf_num > 0)
+		dev->xfer_buf_num = buf_num;
+	else if (!bufs)
+		dev->xfer_buf_num = DEFAULT_BUF_NUMBER;
+	else
+		return -3;
+
+	if (buf_len > 0 && buf_len % 512 == 0) /* len must be multiple of 512 */
+		dev->xfer_buf_len = buf_len;
+	else if (!bufs)
+		dev->xfer_buf_len = DEFAULT_BUF_LENGTH;
+	else
+		return -4;
+
 	dev->async_status = RTLSDR_RUNNING;
 	dev->async_cancel = 0;
 
 	dev->cb = cb;
 	dev->cb_ctx = ctx;
 
-	if (buf_num > 0)
-		dev->xfer_buf_num = buf_num;
-	else
-		dev->xfer_buf_num = DEFAULT_BUF_NUMBER;
-
-	if (buf_len > 0 && buf_len % 512 == 0) /* len must be multiple of 512 */
-		dev->xfer_buf_len = buf_len;
-	else
-		dev->xfer_buf_len = DEFAULT_BUF_LENGTH;
-
-	_rtlsdr_alloc_async_buffers(dev);
+	_rtlsdr_alloc_async_buffers(dev, bufs);
 
 	for(i = 0; i < dev->xfer_buf_num; ++i) {
 		libusb_fill_bulk_transfer(dev->xfer[i],


### PR DESCRIPTION
 Some platforms have specific requirements for buffers used in DSP
operations. Such requirements may include alignment, allocation
in specific memory region, and so on.

 Now librtlsdr allocate buffers for data by standard malloc() call,
which may be inconvinient on such platforms, as data received
from device should be copied in callback before processing.

 This new API call allows client code to provide pre-allocated
buffers for data and avoid additional data copying.

 This method doesn't work via RPC.