### PR TITLE
Specify number of seconds to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ rtl-sdr turns your Realtek RTL2832 based DVB dongle into a SDR receiver
 
 # For more information see:
 
-http://sdr.osmocom.org/trac/wiki/rtl-sdr
+http://osmocom.org/projects/sdr/wiki/Rtl-sdr

--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -547,7 +547,7 @@ static int r82xx_set_pll(struct r82xx_priv *priv, uint32_t freq)
 	}
 
 	if (!(data[2] & 0x40)) {
-		fprintf(stderr, "[R82XX] PLL not locked!\n");
+		fprintf(stderr, "[R82XX] PLL not locked for %u Hz!\n", freq);
 		priv->has_lock = 0;
 		return 0;
 	}


### PR DESCRIPTION
Add a "-R nnn" option to run rtl_fm for a specific number of second, and cleanly exit after this time. Inspired by a similar option "-T" in https://github.com/merbanan/rtl_433