### PR TITLE
debianize: Add kernel module blacklist to librtlsdr0 package

### DIFF
--- a/debian/debianize_armhf
+++ b/debian/debianize_armhf
@@ -14,6 +14,7 @@ rm -fr /tmp/librtlsdr0/
 mkdir -p /tmp/librtlsdr0/
 mkdir -p /tmp/librtlsdr0/usr/lib/arm-linux-gnueabihf/
 mkdir -p /tmp/librtlsdr0/DEBIAN
+mkdir -p /tmp/librtlsdr0/etc/modprobe.d/
 
 cat <<- EOF > /tmp/librtlsdr0/DEBIAN/control
 Package: librtlsdr0
@@ -32,6 +33,15 @@ Description: Software defined radio receiver for Realtek RTL2832U (library)
  low-cost DVB-T/DAB(+) USB dongles based on the Realtek RTL2832U chip.
  .
  This package contains the shared library.
+EOF
+
+cat <<- EOF > /tmp/librtlsdr0/etc/modprobe.d/rtl-sdr-blacklist.conf
+# This system has librtlsdr0 installed in order to
+# use digital video broadcast receivers as generic
+# software defined radios.
+blacklist dvb_usb_rtl28xxu
+blacklist e4000
+blacklist rtl2832
 EOF
 
 DEB_PKG="librtlsdr0_${VERSION}_armhf.deb"

--- a/debian/debianize_x32
+++ b/debian/debianize_x32
@@ -34,6 +34,15 @@ Description: Software defined radio receiver for Realtek RTL2832U (library)
  This package contains the shared library.
 EOF
 
+cat <<- EOF > /tmp/librtlsdr0/etc/modprobe.d/rtl-sdr-blacklist.conf
+# This system has librtlsdr0 installed in order to
+# use digital video broadcast receivers as generic
+# software defined radios.
+blacklist dvb_usb_rtl28xxu
+blacklist e4000
+blacklist rtl2832
+EOF
+
 DEB_PKG="librtlsdr0_${VERSION}_i386.deb"
 
 cp -rf ${REPO_DIR}/build/src/lib*so* /tmp/librtlsdr0/usr/lib/i386-linux-gnu/

--- a/debian/debianize_x64
+++ b/debian/debianize_x64
@@ -34,6 +34,15 @@ Description: Software defined radio receiver for Realtek RTL2832U (library)
  This package contains the shared library.
 EOF
 
+cat <<- EOF > /tmp/librtlsdr0/etc/modprobe.d/rtl-sdr-blacklist.conf
+# This system has librtlsdr0 installed in order to
+# use digital video broadcast receivers as generic
+# software defined radios.
+blacklist dvb_usb_rtl28xxu
+blacklist e4000
+blacklist rtl2832
+EOF
+
 DEB_PKG="librtlsdr0_${VERSION}_amd64.deb"
 
 cp -rf ${REPO_DIR}/build/src/lib*so* /tmp/librtlsdr0/usr/lib/x86_64-linux-gnu/


### PR DESCRIPTION
This linux video driver blacklist was introduced in librtlsdr0 with
version 0.5.3-2 and later removed with version 0.5.3-10 [1].

The removal was accompanied by the (re-)activation of the automatic
detachment of the the kernel driver (DETACH_KERNEL_DRIVER=ON) [2] for
debian package builds. Since the debianize_scripts in this fork
doesn't enforce specific compile time options (caused by the lack of
a debian/rules file), it should be considered that this option isn't set.
Thus the installation of the blacklist is added in this commit.

[1]: "* Have librtlsdr0 also install a blacklist for linux video drivers"
     "  * Enable DETACH_KERNEL_DRIVER (Closes: 823022)"
     "* remove rtl-sdr-blacklist.conf on upgrade. Thanks Bob! (Closes: #829517)",
     https://anonscm.debian.org/cgit/users/bottoms/pkg-rtl-sdr.git/tree/debian/changelog

[2]: "lib: don't detach kernel driver by default"
     https://github.com/steve-m/librtlsdr/commit/3e17ef2b55d80237da9766f3464ae784448a23e6

Fixes librtlsdr/librtlsdr#19.