### PR TITLE
new API function rtlsdr_set_opt_string()

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -449,6 +449,32 @@ RTLSDR_API int rtlsdr_ir_query(rtlsdr_dev_t *dev, uint8_t *buf, size_t buf_len);
  */
 RTLSDR_API int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on);
 
+/*!
+ * Sets multiple options from a string encoded like "bw=300:agc=0:gain=27.3:dagc=0:T=1".
+ * this is a helper function, that programs don't need to implement every single option
+ *   at the command line interface.
+ * Options are seperated by colon ':'.
+ * There mustn't be extra spaces between option name and '='.
+ * option 'f' set center frequency as in rtlsdr_set_center_freq()
+ * option 'bw' sets tuner bandwidth as in rtlsdr_set_tuner_bandwidth()
+ *   - but value is in kHz.
+ * option 'agc' sets tuner gain mode as with rtlsdr_set_tuner_gain_mode():
+ *   '1' means manual gain mode shall be enabled.
+ * option 'gain' sets tuner gain as with rtlsdr_set_tuner_gain():
+ *   values in tenth dB.
+ * option 'dagc' or 'dgc' de/activates digital agc as with rtlsdr_set_agc_mode().
+ *   value 1 to enable. 0 to disable.
+ * option 'ds' set direct sampling as with rtlsdr_set_direct_sampling():
+ *   '0' to deactivate, '1' or 'i' for I-ADC input, '2' or 'q' for Q-ADC input
+ * option 't' or 'T' for enabling bias tee on GPIO PIN 0 as with rtlsdr_set_bias_tee():
+ *   '1' for Bias T on. '0' for Bias T off.
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \param opts described option string
+ * \param verbose print parsed options to stderr
+ */
+RTLSDR_API int rtlsdr_set_opt_string(rtlsdr_dev_t *dev, const char *opts, int verbose);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rtl_test.c
+++ b/src/rtl_test.c
@@ -91,6 +91,9 @@ void usage(void)
 		"Usage:\n"
 		"\t[-s samplerate (default: 2048000 Hz)]\n"
 		"\t[-d device_index or serial (default: 0)]\n"
+		"\t[-O set RTL options string seperated with ':' ]\n"
+		"\t  f=<freqHz>:bw=<bw_in_kHz>:agc=<tuner_gain_mode>:gain=<tenth_dB>\n"
+		"\t  dagc=<rtl_agc>:ds=<direct_sampling_mode>:T=<bias_tee>\n"
 		"\t[-t enable Elonics E4000 tuner benchmark]\n"
 #ifndef _WIN32
 		"\t[-p[seconds] enable PPM error measurement (default: 10 seconds)]\n"
@@ -308,6 +311,7 @@ int main(int argc, char **argv)
 #endif
 	int n_read, r, opt, i;
 	int sync_mode = 0;
+	const char * rtlOpts = NULL;
 	uint8_t *buffer;
 	int dev_index = 0;
 	int dev_given = 0;
@@ -315,7 +319,7 @@ int main(int argc, char **argv)
 	int count;
 	int gains[100];
 
-	while ((opt = getopt(argc, argv, "d:s:b:tp::Sh")) != -1) {
+	while ((opt = getopt(argc, argv, "d:s:b:O:tp::Sh")) != -1) {
 		switch (opt) {
 		case 'd':
 			dev_index = verbose_device_search(optarg);
@@ -326,6 +330,9 @@ int main(int argc, char **argv)
 			break;
 		case 'b':
 			out_block_size = (uint32_t)atof(optarg);
+			break;
+		case 'O':
+			rtlOpts = optarg;
 			break;
 		case 't':
 			test_mode = TUNER_BENCHMARK;
@@ -400,6 +407,10 @@ int main(int argc, char **argv)
 			fprintf(stderr, "No E4000 tuner found, aborting.\n");
 
 		goto exit;
+	}
+
+	if (rtlOpts) {
+		rtlsdr_set_opt_string(dev, rtlOpts, 1);
 	}
 
 	/* Enable test mode */


### PR DESCRIPTION
* idea is, that CLI programs don't need to implement
  every single RTL option themselves
* option '-O' for test in rtl_test and rtl_fm
