### PR TITLE
Attempt in fixing the autotools build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = foreign dist-bzip2 1.6
 ACLOCAL_AMFLAGS = -I m4
 
-INCLUDES = $(all_includes) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(all_includes) -I$(top_srcdir)/include
 SUBDIRS = include src
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/configure.ac
+++ b/configure.ac
@@ -4,9 +4,6 @@ AC_INIT([librtlsdr],
 
 AM_INIT_AUTOMAKE([dist-bzip2])
 
-dnl kernel style compile messages
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
-
 dnl checks for programs
 AC_PROG_MAKE_SET
 AC_PROG_CC
@@ -18,6 +15,9 @@ AC_PROG_LIBTOOL
 PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0)
 LIBS="$LIBS $LIBUSB_LIBS"
 CFLAGS="$CFLAGS $LIBUSB_CFLAGS"
+
+AC_SUBST(MAJOR_VERSION,["0"])
+AC_SUBST(MINOR_VERSION,["8"])
 
 AC_PATH_PROG(DOXYGEN,doxygen,false)
 AM_CONDITIONAL(HAVE_DOXYGEN, test $DOXYGEN != false)
@@ -105,9 +105,10 @@ dnl Generate the output
 AC_CONFIG_HEADER(config.h)
 
 AC_OUTPUT(
-	librtlsdr.pc
-	include/Makefile
-	src/Makefile
-	Makefile
-	Doxyfile
+        librtlsdr.pc
+        include/Makefile
+        src/Makefile
+        Makefile
+        Doxyfile
+        src/rtl_app_ver.h
 )

--- a/librtlsdr.pc.in
+++ b/librtlsdr.pc.in
@@ -7,5 +7,5 @@ Name: RTL-SDR Library
 Description: C Utility Library
 Version: @VERSION@
 Cflags: -I${includedir}/ @RTLSDR_PC_CFLAGS@
-Libs: -L${libdir} -lrtlsdr -lusb-1.0
+Libs: -L${libdir} -lrtlsdr
 Libs.private: @RTLSDR_PC_LIBS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@
 LIBVERSION=0:5:0
 
 AUTOMAKE_OPTIONS = subdir-objects
-INCLUDES = $(all_includes) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(all_includes) -I$(top_srcdir)/include
 noinst_HEADERS = convenience/convenience.h
 AM_CFLAGS = ${CFLAGS} -fPIC ${SYMBOL_VISIBILITY}
 
@@ -14,29 +14,30 @@ librtlsdr_la_LDFLAGS = -version-info $(LIBVERSION)
 
 bin_PROGRAMS         = rtl_sdr rtl_tcp rtl_test rtl_fm rtl_ir rtl_eeprom rtl_adsb rtl_power rtl_rpcd
 
-rtl_sdr_SOURCES      = rtl_sdr.c convenience/convenience.c
+rtl_sdr_SOURCES      = rtl_sdr.c convenience/convenience.c convenience/rtl_convenience.c convenience/wavewrite.c
 rtl_sdr_LDADD        = librtlsdr.la
 
-rtl_tcp_SOURCES      = rtl_tcp.c convenience/convenience.c
+rtl_tcp_SOURCES      = rtl_tcp.c controlThread.c convenience/convenience.c convenience/rtl_convenience.c
 rtl_tcp_LDADD        = librtlsdr.la
 
-rtl_test_SOURCES      = rtl_test.c convenience/convenience.c
+rtl_test_SOURCES      = rtl_test.c convenience/convenience.c convenience/rtl_convenience.c
 rtl_test_LDADD        = librtlsdr.la $(LIBM)
 
-rtl_fm_SOURCES      = rtl_fm.c convenience/convenience.c
+rtl_fm_SOURCES      = rtl_fm.c convenience/convenience.c convenience/rtl_convenience.c convenience/wavewrite.c
 rtl_fm_LDADD        = librtlsdr.la $(LIBM)
 
-rtl_ir_SOURCES      = rtl_ir.c convenience/convenience.c
+rtl_ir_SOURCES      = rtl_ir.c convenience/convenience.c convenience/rtl_convenience.c
 rtl_ir_LDADD        = librtlsdr.la $(LIBM)
 
-rtl_eeprom_SOURCES      = rtl_eeprom.c convenience/convenience.c
+rtl_eeprom_SOURCES      = rtl_eeprom.c convenience/convenience.c convenience/rtl_convenience.c
 rtl_eeprom_LDADD        = librtlsdr.la $(LIBM)
 
-rtl_adsb_SOURCES      = rtl_adsb.c convenience/convenience.c
+rtl_adsb_SOURCES      = rtl_adsb.c convenience/convenience.c convenience/rtl_convenience.c
 rtl_adsb_LDADD        = librtlsdr.la $(LIBM)
 
-rtl_power_SOURCES     = rtl_power.c convenience/convenience.c
+rtl_power_SOURCES     = rtl_power.c convenience/convenience.c convenience/rtl_convenience.c
 rtl_power_LDADD       = librtlsdr.la $(LIBM)
 
-rtl_rpcd_SOURCES     = rtl_rpcd.c rtlsdr_rpc_msg.c convenience/convenience.c
+rtl_rpcd_SOURCES     = rtl_rpcd.c rtlsdr_rpc_msg.c convenience/convenience.c convenience/rtl_convenience.c
+rtl_rpcd_CFLAGS      = $(AM_CFLAGS) $(AM_CPPFLAGS)
 rtl_rpcd_LDADD       = librtlsdr.la

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -44,6 +44,7 @@ typedef int socklen_t;
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <limits.h>
 
 #ifndef _WIN32
 #define min(a, b) (((a) < (b)) ? (a) : (b))


### PR DESCRIPTION
After some discoveries downstream at https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255725
I discovered that the code has been forked(?). Certainly an official statement on which of the repos
librtlsdr/librtlsdr or steve-m/librtlsdr is the official one would be appreciated. This is a little confusing.
However, I assumed that this one is where development is being continued now, as the last release is 0.8.0 whereas at the steve-m repo it is 0.6.0.

Moving on to actually building, I saw that the entire autotools buildsystem must have not been seriously taken care of in quite some time. I patched the various build failures and it appears to be working now.
Also, an include of `limits.h` was missing for the `INT_MAX` symbol in `src/librtlsdr.c`, so I added that as well.

I would appreciate a feedback on whether the dependencies of the binaries/libraries are even with the CMake build, such that there are no API differences between both build tools.

Tested to work on:
```
[nico@hades ~]$ uname -apKU
FreeBSD hades.herrhotzenplotz.geek 13.0-RELEASE FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 04:24:09 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC  amd64 amd64 1300139 1300139
[nico@hades ~]$ freebsd-version
13.0-RELEASE
[nico@hades ~]$ 
```