### PR TITLE
Fix cmake_minimum_required to avoid warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(rtlsdr C)
 
 # quite old cmake version - probably for compatibility with old OS versions?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.6...3.19)
 project(rtlsdr C)
 
 # quite old cmake version - probably for compatibility with old OS versions?


### PR DESCRIPTION
cmake 3.19 warns about dropped compatibility for cmake less than 2.8.12 in the future. This patch updates the minimum required version to 2.8.12 to avoid the warning.

cmake 2.8.12 was released in 2013 so it should be safe to update the minimum required version from 2.6 to 2.8.12 without loosing support for older os versions. See issue #111.