### PR TITLE
Make librtlsdr cmake subdirectory friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
 if(NOT LIB_INSTALL_DIR)
    set(LIB_INSTALL_DIR lib)
@@ -128,7 +128,7 @@ endif()
 # Setup the include and linker paths
 ########################################################################
 include_directories(
-    ${CMAKE_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include
     ${LIBUSB_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/src
     ${THREADS_PTHREADS_INCLUDE_DIR}
@@ -145,7 +145,7 @@ include_directories(
 # Create uninstall target
 ########################################################################
 configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
+    ${PROJECT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
 @ONLY)
 

--- a/cmake/Modules/Version.cmake
+++ b/cmake/Modules/Version.cmake
@@ -32,12 +32,12 @@ set(PATCH_VERSION ${VERSION_INFO_PATCH_VERSION})
 ########################################################################
 find_package(Git QUIET)
 
-if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
+if(GIT_FOUND AND EXISTS ${PROJECT_SOURCE_DIR}/.git)
     message(STATUS "Extracting version information from git describe...")
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=4 --long
         OUTPUT_VARIABLE GIT_DESCRIBE OUTPUT_STRIP_TRAILING_WHITESPACE
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
 else()
     set(GIT_DESCRIBE "v${MAJOR_VERSION}.${MINOR_VERSION}.x-xxx-xunknown")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 # Set up Windows DLL resource files
 ########################################################################
 IF(MSVC)
-    include(${CMAKE_SOURCE_DIR}/cmake/Modules/Version.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/Modules/Version.cmake)
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/rtlsdr.rc.in


### PR DESCRIPTION
Change CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR to allow for inclusion of librtlsdr as a subdirectory in another cmake project. For a standalone build, PROJECT_SOURCE_DIR and CMAKE_SOURCE_DIR work pretty much the same, but if a projet is included into another with add_subdirectory PROJECT_SOURCE_DIR must be used. See issue #113.