### PR TITLE
Add optional API to keep async read buffers

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -556,6 +556,16 @@ RTLSDR_API int rtlsdr_read_async(rtlsdr_dev_t *dev,
 				 uint32_t buf_len);
 
 /*!
+ * Cleanup async buffers.
+ * This is implicitly done in rtlsdr_close() and
+ * not allowed to call while rtlsdr_read_async() is running.
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \return 0 on success
+ */
+RTLSDR_API int rtlsdr_cleanup_async(rtlsdr_dev_t *dev);
+
+/*!
  * Cancel all pending asynchronous operations on the device.
  * Due to incomplete concurrency implementation, this should
  * only be called from within the callback function, so it is


### PR DESCRIPTION
Introduce (optional) `rtlsdr_cleanup_async()` and by default keep buffers until `rtlsdr_close()`.
See #121 for discussion of the idea.