### PR TITLE
Fix compilation in mingw

### DIFF
--- a/src/convenience/wavewrite.c
+++ b/src/convenience/wavewrite.c
@@ -23,7 +23,7 @@
 #include <time.h>
 #include <assert.h>
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <unistd.h>
 #include <sys/time.h>
 #else


### PR DESCRIPTION
I am currently contribugint to MSYS by adding rtl-sdr as a package. In the process, I found that a patch was required to compile the software in MinGW due to minor problems with includes...

This proposes a fix to avoid having to patch source for MSYS distribution.

See https://github.com/msys2/MINGW-packages/pull/17459 for more info.

Thanks